### PR TITLE
Fix #5 - Add checks for primary and autoincrement

### DIFF
--- a/tests/SpotTest/Entity/NoSerial.php
+++ b/tests/SpotTest/Entity/NoSerial.php
@@ -1,0 +1,23 @@
+<?php
+namespace SpotTest\Entity;
+
+use Spot\Entity;
+use Spot\Mapper;
+
+/**
+ * Entity with no serial/autoincrement
+ *
+ * @package Spot
+ */
+class NoSerial extends \Spot\Entity
+{
+    protected static $table = 'test_noserial';
+
+    public static function fields()
+    {
+        return [
+            'id'    => ['type' => 'integer', 'primary' => true],
+            'data'  => ['type' => 'string', 'required' => true],
+        ];
+    }
+}

--- a/tests/SpotTest/Insert.php
+++ b/tests/SpotTest/Insert.php
@@ -6,7 +6,7 @@ namespace SpotTest;
  */
 class Insert extends \PHPUnit_Framework_TestCase
 {
-    private static $entities = ['Post', 'Author', 'Event', 'Event\Search'];
+    private static $entities = ['Post', 'Author', 'Event', 'Event\Search', 'NoSerial'];
 
     public static function setupBeforeClass()
     {
@@ -199,12 +199,36 @@ class Insert extends \PHPUnit_Framework_TestCase
      */
     public function testCreateWithErrorsThrowsException()
     {
-        $mapper = test_spot_mapper('\SpotTest\Entity\Event');
+        $mapper = test_spot_mapper('SpotTest\Entity\Event');
         $event = $mapper->create([
             'title' => 'Test Event 1',
             'description' => 'Test Description',
             'date_start' => new \DateTime('+1 day')
         ]);
+    }
+
+    public function testInsertWithoutAutoIncrement()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\NoSerial');
+        $entity = $mapper->build([
+            'id' => 101,
+            'data' => 'Testing insert'
+        ]);
+        $result = $mapper->insert($entity);
+
+        $this->assertEquals(101, $result);
+    }
+
+    public function testInsertWithoutAutoIncrementWithoutPKValueHasValidationError()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\NoSerial');
+        $entity = $mapper->build([
+            'data' => 'Testing insert'
+        ]);
+        $result = $mapper->insert($entity);
+
+        $this->assertEquals(false, $result);
+        $this->assertEquals(1, count($entity->errors('id')));
     }
 }
 


### PR DESCRIPTION
- Return provided value for primary key if given on insert
- Check to ensure autoincrement is defined before returning
  'lastInsertId' or equivalent from `insert` method
- Allow custom 'sequence_name' for PostgreSQL autoincrement
- Validate primary key as required if primary but not autoincrement
