### PR TITLE
Fix #19 by returning NULL on non-loaded relation

### DIFF
--- a/lib/Spot/Entity.php
+++ b/lib/Spot/Entity.php
@@ -431,6 +431,17 @@ abstract class Entity implements EntityInterface, \JsonSerializable
     }
 
     /**
+     * Helper function so entity can be accessed via relation in a more
+     * consistent manner with 'entity()' without any errors (i.e. relation will
+     * not error if it already has a loaded entity object - it just returns
+     * $this)
+     */
+    public function entity()
+    {
+        return $this;
+    }
+
+    /**
      * Return array for json_encode()
      */
     public function jsonSerialize()

--- a/lib/Spot/Mapper.php
+++ b/lib/Spot/Mapper.php
@@ -146,6 +146,11 @@ class Mapper implements MapperInterface
             $localValue = $this->primaryKey($entity);
         }
 
+        if (!is_subclass_of($entityName, 'Spot\EntityInterface')) {
+            throw new \InvalidArgumentException("Related entity name must be a "
+                . "valid entity that extends Spot\Entity. Given '" .  $entityName . "'.");
+        }
+
         return new Relation\HasMany($this, $entityName, $foreignKey, $this->primaryKeyField(), $localValue);
     }
 
@@ -156,6 +161,16 @@ class Mapper implements MapperInterface
     {
         $localPkField = $this->primaryKeyField();
         $localValue = $entity->$localPkField;
+
+        if (!is_subclass_of($hasManyEntity, 'Spot\EntityInterface')) {
+            throw new \InvalidArgumentException("Related entity name must be a "
+                . "valid entity that extends Spot\Entity. Given '" .  $hasManyEntity . "'.");
+        }
+
+        if (!is_subclass_of($throughEntity, 'Spot\EntityInterface')) {
+            throw new \InvalidArgumentException("Related entity name must be a "
+                . "valid entity that extends Spot\Entity. Given '" .  $throughEntity . "'.");
+        }
 
         return new Relation\HasManyThrough($this, $hasManyEntity, $throughEntity, $selectField, $whereField, $localValue);
     }
@@ -168,6 +183,11 @@ class Mapper implements MapperInterface
     public function hasOne(EntityInterface $entity, $foreignEntity, $foreignKey)
     {
         $localKey = $this->primaryKeyField();
+
+        if (!is_subclass_of($foreignEntity, 'Spot\EntityInterface')) {
+            throw new \InvalidArgumentException("Related entity name must be a "
+                . "valid entity that extends Spot\Entity. Given '" .  $foreignEntity . "'.");
+        }
 
         // Return relation object so query can be lazy-loaded
         return new Relation\HasOne($this, $foreignEntity, $foreignKey, $localKey, $entity->$localKey);
@@ -182,6 +202,11 @@ class Mapper implements MapperInterface
      */
     public function belongsTo(EntityInterface $entity, $foreignEntity, $localKey)
     {
+        if (!is_subclass_of($foreignEntity, 'Spot\EntityInterface')) {
+            throw new \InvalidArgumentException("Related entity name must be a "
+                . "valid entity that extends Spot\Entity. Given '" .  $foreignEntity . "'.");
+        }
+
         $foreignMapper = $this->getMapper($foreignEntity);
         $foreignKey = $foreignMapper->primaryKeyField();
 

--- a/lib/Spot/Relation/BelongsTo.php
+++ b/lib/Spot/Relation/BelongsTo.php
@@ -74,11 +74,23 @@ class BelongsTo extends RelationAbstract implements \ArrayAccess
         return $this->result;
     }
 
+    /**
+     * Helper function to return the entity
+     */
+    public function entity()
+    {
+        return $this->execute();
+    }
+
     // Magic getter/setter passthru
     // ----------------------------------------------
     public function __get($key)
     {
-        $this->execute()->$key;
+        $entity = $this->execute();
+        if ($entity) {
+            return $entity->$key;
+        }
+        return null;
     }
 
     public function __set($key, $val)

--- a/lib/Spot/Relation/HasOne.php
+++ b/lib/Spot/Relation/HasOne.php
@@ -63,11 +63,23 @@ class HasOne extends RelationAbstract implements \ArrayAccess
         return $this->result;
     }
 
+    /**
+     * Helper function to return the entity
+     */
+    public function entity()
+    {
+        return $this->execute();
+    }
+
     // Magic getter/setter passthru
     // ----------------------------------------------
     public function __get($key)
     {
-        $this->execute()->$key;
+        $entity = $this->execute();
+        if ($entity) {
+            return $entity->$key;
+        }
+        return null;
     }
 
     public function __set($key, $val)

--- a/tests/SpotTest/Relations.php
+++ b/tests/SpotTest/Relations.php
@@ -244,4 +244,40 @@ class Relations extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('SpotTest\Entity\Event', $event);
         $this->assertEquals($event->id, $eventId);
     }
+
+    /**
+     * @depends testEventInsert
+     */
+    public function testEventSearchEntityAccessibleWithEntityMethod($eventId)
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Event\Search');
+        $eventSearch = $mapper->first(['event_id' => $eventId]);
+        $event = $eventSearch->event->entity();
+        $this->assertInstanceOf('SpotTest\Entity\Event', $event);
+        $this->assertEquals($event->id, $eventId);
+    }
+
+    /**
+     * @depends testEventInsert
+     */
+    public function testEventSearchEntityMethodCalledOnEntityDoesNotError($eventId)
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Event\Search');
+        $eventSearch = $mapper->first(['event_id' => $eventId]);
+        $event = $eventSearch->event->entity()->entity();
+        $this->assertInstanceOf('SpotTest\Entity\Event', $event);
+        $this->assertEquals($event->id, $eventId);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testInvalidRelationClass()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Post');
+        $entity = $mapper->first();
+        $entity->fake = $mapper->hasOne($entity, 'Nonexistent\Entity', 'fake_field');
+
+        $entity->fake->something;
+    }
 }


### PR DESCRIPTION
- Added 'entity()' method to single relations and Entity object so you
  can always call '$relation->entity()' without error, even if a loaded
  Entity object had already been set over the temporary relation object
- Added more class checks to ensure specified relation class is a valid
  Spot\Entity object
