### PR TITLE
Fixed to work with HHVM

### DIFF
--- a/lib/Spot/EntityInterface.php
+++ b/lib/Spot/EntityInterface.php
@@ -36,7 +36,7 @@ interface EntityInterface
     /**
      * Return defined fields of the entity
      */
-    public static function relations(MapperInterface $mapper, self $entity);
+    public static function relations(MapperInterface $mapper, EntityInterface $entity);
 
     /**
      * Return scopes defined by this entity. Scopes are called from the


### PR DESCRIPTION
From my understanding, HHVM doesn't support `self` to be used for function argument type hinting; therefore it keeps giving parser error. So, changing self to the actual class name solves the problem. Also, if anyone still has a problem with using it because of Doctrine errors, use the dev-master branch as the type hintings have become compatible with the HHVM.
