### PR TITLE
Change REGEX to REGEXP

### DIFF
--- a/lib/Spot/Query.php
+++ b/lib/Spot/Query.php
@@ -275,7 +275,7 @@ class Query implements \Countable, \IteratorAggregate, \ArrayAccess
                 case '~=':
                 case '=~':
                 case ':regex':
-                    $operator = "REGEX";
+                    $operator = "REGEXP";
                 break;
                 // LIKE
                 case ':like':

--- a/tests/SpotTest/QuerySql.php
+++ b/tests/SpotTest/QuerySql.php
@@ -130,6 +130,18 @@ class QuerySql extends \PHPUnit_Framework_TestCase
         $this->assertEquals(6, $mapper->where(['status :gte' => 5])->count());
     }
 
+    // Regexp
+    public function testOperatorRegexp()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Post');
+        // "REGEXP" only supported by MySQL
+        if (!$mapper->connectionIs('mysql')) {
+            $this->markTestSkipped('Not supported in Sqlite nor Postgres.');
+        }
+        $this->assertEquals(10, $mapper->where(['title :regex' => '_title$'])->count());
+        $this->assertEquals(5, $mapper->where(['title :regex' => '^odd_'])->count());
+    }
+
     // Ordering
     public function testOrderBy()
     {


### PR DESCRIPTION
MySQL does not have expression called `REGEX`. Correct name is [REGEXP](http://dev.mysql.com/doc/refman/4.1/en/regexp.html). Before PR the following code dies with error:

``` php
$mapper->where(["title :regex" => "_foo$"])
```

```
PDOException: SQLSTATE[42000]: Syntax error or access violation: 1064
```
