### PR TITLE
Fix #31 - Custom setter breaks Entity::isModified()

### DIFF
--- a/lib/Spot/Entity.php
+++ b/lib/Spot/Entity.php
@@ -227,7 +227,14 @@ abstract class Entity implements EntityInterface, \JsonSerializable
             }
         }
 
-        return !!count($this->_dataModified);
+        /* Check if any of values really has changed. */
+        foreach (array_keys($this->_dataModified) as $field) {
+            if (true === $this->isModified($field)) {
+                return true;
+            }
+        };
+
+        return false;
     }
 
     /**

--- a/tests/SpotTest/Entity.php
+++ b/tests/SpotTest/Entity.php
@@ -6,7 +6,7 @@ namespace SpotTest;
  */
 class Entity extends \PHPUnit_Framework_TestCase
 {
-    private static $entities = ['Post', 'Author'];
+    private static $entities = ['Post', 'Author', 'CustomMethods'];
 
     public static function setupBeforeClass()
     {
@@ -291,6 +291,25 @@ class Entity extends \PHPUnit_Framework_TestCase
         $data = $entity->data();
 
         $this->assertEquals('test_test_gotten', $data['test1']);
+    }
+
+    public function testCustomSetterShouldNotTriggerModified()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\CustomMethods');
+
+        $entity = new \SpotTest\Entity\CustomMethods([
+            'test1' => 'test',
+            'test2' => 'copy'
+        ]);
+        $id = $mapper->save($entity);
+
+        unset($entity);
+
+        $entity = $mapper->get($id);
+        $this->assertFalse($entity->isModified('test1'));
+        $this->assertFalse($entity->isModified('test2'));
+        $this->assertFalse($entity->isModified('test3'));
+        $this->assertFalse($entity->isModified());
     }
 
     public function testGetPrimaryKeyField()

--- a/tests/SpotTest/Entity/CustomMethods.php
+++ b/tests/SpotTest/Entity/CustomMethods.php
@@ -15,7 +15,8 @@ class CustomMethods extends \Spot\Entity
         return [
             'id' => ['type' => 'integer', 'primary' => true, 'autoincrement' => true],
             'test1' => ['type' => 'text'],
-            'test2' => ['type' => 'text']
+            'test2' => ['type' => 'text'],
+            'test3' => ['type' => 'text']
         ];
     }
 
@@ -23,6 +24,12 @@ class CustomMethods extends \Spot\Entity
     public function setTest1($value)
     {
         return $value . '_test';
+    }
+
+    public function setTest2($value)
+    {
+        $this->test3 = $value . '_copy';
+        return $value;
     }
 
     // Custom getter


### PR DESCRIPTION
Instead of checking if `_dataModified` size is non-zero loop through all properties in the array and check if value has really changed. Not sure if this is the correct way. Maybe `set()` should be changed so that it does not mark properties dirty when new value is the same as old value?
