### PR TITLE
Namespace issue with relations() interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,9 @@ $mapper->hasOne(Entity $entity, $foreignEntity, $foreignKey)
 ```php
 namespace Entity;
 
+use Spot\EntityInterface as Entity;
+use Spot\MapperInterface as Mapper;
+
 class User extends \Spot\Entity
 {
     protected static $table = 'users';
@@ -488,6 +491,9 @@ $mapper->belongsTo(Entity $entity, $foreignEntity, $localKey)
 
 ```php
 namespace Entity;
+
+use Spot\EntityInterface as Entity;
+use Spot\MapperInterface as Mapper;
 
 class Post extends \Spot\Entity
 {
@@ -538,6 +544,9 @@ $mapper->hasMany(Entity $entity, $entityName, $foreignKey, $localValue = null)
 We start by adding a `comments` relation to our `Post` object:
 ```php
 namespace Entity;
+
+use Spot\EntityInterface as Entity;
+use Spot\MapperInterface as Mapper;
 
 class Post extends Spot\Entity
 {


### PR DESCRIPTION
Fatal error: Declaration of xx::relations() must be compatible with Spot\EntityInterface::relations(Spot\MapperInterface $mapper, Spot\EntityInterface $entity
