### PR TITLE
Allow eager-loaded many relations to use the custom Collection class

### DIFF
--- a/lib/Spot/Relation/HasMany.php
+++ b/lib/Spot/Relation/HasMany.php
@@ -64,6 +64,7 @@ class HasMany extends RelationAbstract implements \Countable, \IteratorAggregate
         $relationForeignKey = $this->foreignKey();
         $relationEntityKey = $this->entityKey();
         $collectionRelations = $this->query();
+        $collectionClass = $this->mapper()->getMapper($this->entityName())->collectionClass();
 
         // Divvy up related objects for each entity by foreign key value
         // ex. comment foreignKey 'post_id' will == entity primaryKey value
@@ -75,7 +76,7 @@ class HasMany extends RelationAbstract implements \Countable, \IteratorAggregate
         // Set relation collections back on each entity object
         foreach ($collection as $entity) {
             if (isset($entityRelations[$entity->$relationEntityKey])) {
-                $entityCollection = new Collection($entityRelations[$entity->$relationEntityKey]);
+                $entityCollection = new $collectionClass($entityRelations[$entity->$relationEntityKey]);
                 $entity->relation($relationName, $entityCollection);
             }
         }

--- a/lib/Spot/Relation/HasManyThrough.php
+++ b/lib/Spot/Relation/HasManyThrough.php
@@ -82,6 +82,7 @@ class HasManyThrough extends RelationAbstract implements \Countable, \IteratorAg
         $relationLocalKey = $this->localKey();     // post_id
         $relationEntityKey = $this->entityKey();
         $collectionRelations = $this->query()->execute();
+        $collectionClass = $this->mapper()->getMapper($this->entityName())->collectionClass();
 
         // HasManyThrough has to map out resulting key to original collection
         // keys since resulting relation objects won't have any reference to
@@ -103,7 +104,7 @@ class HasManyThrough extends RelationAbstract implements \Countable, \IteratorAg
         // Set relation collections back on each entity object
         foreach ($collection as $entity) {
             if (isset($entityRelations[$entity->$relationEntityKey])) {
-                $entityCollection = new Collection($entityRelations[$entity->$relationEntityKey]);
+                $entityCollection = new $collectionClass($entityRelations[$entity->$relationEntityKey]);
                 $entity->relation($relationName, $entityCollection);
             }
         }


### PR DESCRIPTION
When overriding the `$_collectionClass` in a custom Mapper class, it isn't used for eager-loaded collections (many and many_through relations).

This patch fixes it :)
