### PR TITLE
Set relations on entities when eagerLoading, even when the entity has no related objects

### DIFF
--- a/lib/Spot/Relation/HasMany.php
+++ b/lib/Spot/Relation/HasMany.php
@@ -78,6 +78,8 @@ class HasMany extends RelationAbstract implements \Countable, \IteratorAggregate
             if (isset($entityRelations[$entity->$relationEntityKey])) {
                 $entityCollection = new $collectionClass($entityRelations[$entity->$relationEntityKey]);
                 $entity->relation($relationName, $entityCollection);
+            } else {
+                $entity->relation($relationName, new $collectionClass());
             }
         }
 

--- a/lib/Spot/Relation/HasManyThrough.php
+++ b/lib/Spot/Relation/HasManyThrough.php
@@ -106,6 +106,8 @@ class HasManyThrough extends RelationAbstract implements \Countable, \IteratorAg
             if (isset($entityRelations[$entity->$relationEntityKey])) {
                 $entityCollection = new $collectionClass($entityRelations[$entity->$relationEntityKey]);
                 $entity->relation($relationName, $entityCollection);
+            } else {
+                $entity->relation($relationName, new $collectionClass());
             }
         }
 

--- a/lib/Spot/Relation/RelationAbstract.php
+++ b/lib/Spot/Relation/RelationAbstract.php
@@ -122,6 +122,8 @@ abstract class RelationAbstract
         foreach ($collection as $entity) {
             if (isset($entityRelations[$entity->$relationEntityKey])) {
                 $entity->relation($relationName, $entityRelations[$entity->$relationEntityKey]);
+            } else {
+                $entity->relation($relationName, false);
             }
         }
 


### PR DESCRIPTION
I'll try to describe the problem I've been running into as clearly as possible. It's not so easy, but I'll do my best:

1. Load a Collection of Post entities with their tags `$posts->all()->with(['tags']);`
2. Internally, Spot calls `Mapper->collection()` to create the Collection then calls `Mapper->with` to load the requested relations. Then this happens (I'm only putting the critical path):

```php
$singleEntity = $collection->first();
$relationObject = $singleEntity->relation($relationName);
$relationObject->eagerLoadOnCollection($relationName, $collection);
```

And then inside **eagerLoadOnCollection()**:

```
// Set relation collections back on each entity object
foreach ($collection as $entity) {
    if (isset($entityRelations[$entity->$relationEntityKey])) {
        $entity->relation($relationName, $entityRelations[$entity->$relationEntityKey]);
    }
}
```

So Spot uses the RelationAbstract object from the first entity in the Collection. It then loads all the related entities and assign them into each entity from the collection, but **only for entities which have related objects**.

The problem is that if the **first** Post from the Collection doesn't have any **tags**, then doing `foreach ($firstPost->tags as $tag)` will call `execute()` method the RelationAbstract object. But since it's the first post, its RelationAbstract has been used to load all the related entities from the previous collection. The execute() reuses the same query and **all the tags** from all the posts in the collection **gets assigned to this first post**.

The pull-requests forces the Relation to be populated with an empty Collection or `false` for single relations (hasOne and BelongsTo) to prevent this issue.
