### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/tests               export-ignore
+/.gitattributes      export-ignore
+/.gitignore          export-ignore
+/.travis.yml         export-ignore
+/phpunit_mysql.xml   export-ignore
+/phpunit_pgsql.xml   export-ignore
+/phpunit_sqlite.xml  export-ignore


### PR DESCRIPTION
This is a best practice, see here: https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production

Composer supports dist and dev dependencies using .gitignore.

This will ignore all the files listed here for the dist version (production).