### PR TITLE
Update Entity.php

### DIFF
--- a/lib/Spot/Entity.php
+++ b/lib/Spot/Entity.php
@@ -356,6 +356,8 @@ abstract class Entity implements EntityInterface, \JsonSerializable
             $this->_inSetter[$field] = true;
             $value = call_user_func([$this, $setterMethod], $value);
             unset($this->_inSetter[$field]);
+            
+            return $value;
         }
 
         if (in_array($field, self::$relationFields[get_class($this)])) {


### PR DESCRIPTION
otherwise 
1. you are not able to implement a fluent set method for the field
2. if you declared a setMethod which sets a value to the specified field it (like setFooBar($fooBar) for field foo_bar) it will call this set method again through the magic set method of Spot\Entity and then the value will be set here
 
            $this->_data[$field] = $value; // or in modified or relation

but it returns void so after you return to the callee

        if (!in_array($field, $this->_inSetter) && method_exists($this, $setterMethod)) {
            $this->_inSetter[$field] = true;
            $value = call_user_func([$this, $setterMethod], $value); // here
            unset($this->_inSetter[$field]);
        }
        //the $value is null now
        ...
        $this->_data[$field] = $value;
        // and now it overwrites the set value with null