### PR TITLE
Unique fields should only be validated if the field isn't NULL

### DIFF
--- a/lib/Spot/Mapper.php
+++ b/lib/Spot/Mapper.php
@@ -1002,7 +1002,7 @@ class Mapper implements MapperInterface
             }
 
             // Unique field
-            if ($entity->isNew() && isset($fieldAttrs['unique']) && !empty($fieldAttrs['unique'])) {
+            if ($entity->isNew() && isset($fieldAttrs['unique']) && !empty($fieldAttrs['unique']) && $entity->$field !== null) {
                 if (is_string($fieldAttrs['unique'])) {
                     // Named group
                     $fieldKeyName = $fieldAttrs['unique'];


### PR DESCRIPTION
I think that multiple NULL values should be allowed.
 
### Example
#### Entity:
```php
class ExampleEntity extends \Spot\Entity
{
  public static function fields()
  {
    return [
      'vat_number' => ['type' => 'string', 'unique' => true]
    ];
  }
```

#### Insert
```php
$result = $mapper->insert([
    'vat_number' => null
]);
```

#### Generates this validation SQL query:
```sql
'SELECT * FROM example_entity WHERE `example_entity`.`vat_number` IS NULL
```

#### Generates this PHP exception: 
```php
Unable to insert new Entity\ExampleEntity- Errors: array ( 'vat_number' => array (0 => 'Vat Number \'\' is already taken.))
```