### PR TITLE
Perform toArray on eager loaded relationships when running toArray on Entity

### DIFF
--- a/lib/Spot/Entity.php
+++ b/lib/Spot/Entity.php
@@ -130,11 +130,21 @@ abstract class Entity implements EntityInterface, \JsonSerializable
      */
     public function data($data = null, $modified = true)
     {
+        $entityName = get_class($this);
+
         // GET
         if (null === $data || !$data) {
             $data = array_merge($this->_data, $this->_dataModified);
             foreach ($data as $k => &$v) {
                 $v = $this->__get($k, $v);
+            }
+
+            foreach (self::$relationFields[$entityName] as $relationField) {
+                $relation = $this->relation($relationField);
+
+                if ($relation instanceof Entity\Collection) {
+                    $data[$relationField] = $relation->toArray();
+                }
             }
 
             return $data;

--- a/lib/Spot/Entity.php
+++ b/lib/Spot/Entity.php
@@ -142,11 +142,7 @@ abstract class Entity implements EntityInterface, \JsonSerializable
             foreach (self::$relationFields[$entityName] as $relationField) {
                 $relation = $this->relation($relationField);
 
-                if ($relation instanceof Entity\Collection) {
-                    $data[$relationField] = $relation->toArray();
-                }
-
-                if ($relation instanceof EntityInterface) {
+                if ($relation instanceof Entity\Collection || $relation instanceof EntityInterface) {
                     $data[$relationField] = $relation->toArray();
                 }
             }

--- a/lib/Spot/Entity.php
+++ b/lib/Spot/Entity.php
@@ -145,6 +145,10 @@ abstract class Entity implements EntityInterface, \JsonSerializable
                 if ($relation instanceof Entity\Collection) {
                     $data[$relationField] = $relation->toArray();
                 }
+
+                if ($relation instanceof EntityInterface) {
+                    $data[$relationField] = $relation->toArray();
+                }
             }
 
             return $data;

--- a/tests/SpotTest/Entity.php
+++ b/tests/SpotTest/Entity.php
@@ -357,26 +357,4 @@ class Entity extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('A Post', $data['title']);
     }
-
-    public function testRelationsAreNotReturnedWithData()
-    {
-        $post = new \SpotTest\Entity\Post([
-            'title' => 'A Post',
-            'body' => 'A Body',
-            'status' => 0,
-            'data' => ['posts' => 'are cool', 'another field' => 'to serialize'],
-            'date_created' => new \DateTime()
-        ]);
-        $author = new \SpotTest\Entity\Author([
-            'email' => 'user@exmaple.com',
-            'password' => 'password'
-        ]);
-        $post->author = $author;
-
-        $data = $post->data();
-        $this->assertFalse(isset($data['author']));
-
-        $array = $post->toArray();
-        $this->assertFalse(isset($array['author']));
-    }
 }

--- a/tests/SpotTest/RelationsEagerLoading.php
+++ b/tests/SpotTest/RelationsEagerLoading.php
@@ -201,4 +201,24 @@ class RelationsEagerLoading extends \PHPUnit_Framework_TestCase
         // (1 query more than other relations, for the join table)
         $this->assertEquals($startCount+3, $endCount);
     }
+
+    public function testEagerLoadHasManyThroughToArray()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Post');
+        $post = $mapper->all()->with('tags')->first();
+
+        $result = $post->toArray();
+
+        $this->assertTrue(is_array($result['tags']));
+    }
+
+    public function testEagerLoadHasManyThroughToArrayShouldNotLoadRelation()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Post');
+        $post = $mapper->all()->first();
+
+        $result = $post->toArray();
+
+        $this->assertFalse(isset($result['tags']));
+    }
 }

--- a/tests/SpotTest/RelationsEagerLoading.php
+++ b/tests/SpotTest/RelationsEagerLoading.php
@@ -221,4 +221,44 @@ class RelationsEagerLoading extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(isset($result['tags']));
     }
+
+    public function testEagerLoadBelongsToArray()
+    {
+        $mapper = test_spot_mapper('\SpotTest\Entity\Post');
+        $posts = $mapper->all()->with('author')->first();
+
+        $result = $posts->toArray();
+
+        $this->assertTrue(is_array($result['author']));
+    }
+
+    public function testEagerLoadBelongsToArrayShouldNotLoadRelation()
+    {
+        $mapper = test_spot_mapper('\SpotTest\Entity\Post');
+        $posts = $mapper->all()->first();
+
+        $result = $posts->toArray();
+
+        $this->assertFalse(isset($result['author']));
+    }
+
+    public function testEagerLoadHasOneToArray()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Event');
+        $events = $mapper->all()->with('search')->first();
+
+        $result = $events->toArray();
+
+        $this->assertTrue(is_array($result['search']));
+    }
+
+    public function testEagerLoadHasOneToArrayShouldNotLoadRelation()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Event');
+        $events = $mapper->all()->first();
+
+        $result = $events->toArray();
+
+        $this->assertFalse(isset($result['search']));
+    }
 }


### PR DESCRIPTION
When running toArray on an Entity, the eager loaded record(s) are never filled. With this update, if you have eager loaded a relationship using ->with, you will be able to run toArray from an entity and get the data from the relationship.