### PR TITLE
Throw Exception when primary key is missing

### DIFF
--- a/lib/Spot/Mapper.php
+++ b/lib/Spot/Mapper.php
@@ -289,6 +289,10 @@ class Mapper implements MapperInterface
     public function primaryKey(EntityInterface $entity)
     {
         $pkField = $this->entityManager()->primaryKeyField();
+        
+        if (empty($pkField)) {
+            throw new Exception(get_class($entity) . " has no primary key field. Please mark one of its fields as autoincrement or primary.");
+        }
 
         return $entity->$pkField;
     }


### PR DESCRIPTION
Much easier to debug than "Missing argument 1 for Spot\Entity::get()".