### PR TITLE
Enable disabling validation via options

### DIFF
--- a/lib/Spot/Mapper.php
+++ b/lib/Spot/Mapper.php
@@ -289,7 +289,7 @@ class Mapper implements MapperInterface
     public function primaryKey(EntityInterface $entity)
     {
         $pkField = $this->entityManager()->primaryKeyField();
-        
+
         if (empty($pkField)) {
             throw new Exception(get_class($entity) . " has no primary key field. Please mark one of its fields as autoincrement or primary.");
         }
@@ -684,9 +684,11 @@ class Mapper implements MapperInterface
             return false;
         }
 
-        // Run validation
-        if (!$this->validate($entity)) {
-            return false;
+        // Run validation unless disabled via options
+        if (!isset($options['validate']) || (isset($options['validate']) && $options['validate'] !== false)) {
+            if (!$this->validate($entity)) {
+                return false;
+            }
         }
 
         // Ensure there is actually data to update
@@ -780,9 +782,11 @@ class Mapper implements MapperInterface
             return false;
         }
 
-        // Run validation
-        if (!$this->validate($entity)) {
-            return false;
+        // Run validation unless disabled via options
+        if (!isset($options['validate']) || (isset($options['validate']) && $options['validate'] !== false)) {
+            if (!$this->validate($entity)) {
+                return false;
+            }
         }
 
         // Prepare data

--- a/tests/SpotTest/Validation.php
+++ b/tests/SpotTest/Validation.php
@@ -91,4 +91,17 @@ class Test_Validation extends PHPUnit_Framework_TestCase
         $this->assertTrue($entity->hasErrors());
         $this->assertContains("Email must be longer than 4", $entity->errors('email'));
     }
+
+    public function testDisabledValidation()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Author');
+
+        $entity = new SpotTest\Entity\Author([
+            'email' => 't@t',
+            'password' => 'test'
+        ]);
+        $mapper->save($entity, ['validate' => false]);
+
+        $this->assertFalse($entity->hasErrors());
+    }
 }


### PR DESCRIPTION
There are cases when you want to save an entity without validating. For example when creating a stub entity in database which user must then fill with missing properties. This pull request adds possibility of disabling validation by passing boolean `false` as `validate`option.

```php
$mapper->save($entity, ['validate' => false]);
```