### PR TITLE
Cleaning-up PHP doc @return types

### DIFF
--- a/lib/Spot/Config.php
+++ b/lib/Spot/Config.php
@@ -18,8 +18,8 @@ class Config implements \Serializable
      * @param string  $dsn    DSN string for this connection
      * @param boolean $defaut Use this connection as the default? The first connection added is automatically set as the default, even if this flag is false.
      *
-     * @return Doctrine\DBAL\Connection
-     * @throws Spot\Exception
+     * @return \Doctrine\DBAL\Connection
+     * @throws \Spot\Exception
      */
     public function addConnection($name, $dsn, $default = false)
     {
@@ -59,8 +59,8 @@ class Config implements \Serializable
      * Get connection by name
      *
      * @param  string                   $name Unique name of the connection to be returned
-     * @return Doctrine\DBAL\Connection Spot adapter instance
-     * @throws Spot\Exception
+     * @return \Doctrine\DBAL\Connection
+     * @throws \Spot\Exception
      */
     public function connection($name = null)
     {
@@ -89,8 +89,8 @@ class Config implements \Serializable
     /**
      * Get default connection
      *
-     * @return Spot_Adapter_Interface Spot adapter instance
-     * @throws Spot_Exception
+     * @return \Doctrine\DBAL\Connection
+     * @throws \Spot\Exception
      */
     public function defaultConnection()
     {

--- a/lib/Spot/Locator.php
+++ b/lib/Spot/Locator.php
@@ -22,7 +22,7 @@ class Locator
     /**
      * Get config class mapper was instantiated with
      *
-     * @return Spot\Config
+     * @return \Spot\Config
      */
     public function config($cfg = null)
     {
@@ -40,7 +40,7 @@ class Locator
      * Get mapper for specified entity
      *
      * @param  string      $entityName Name of Entity object to load mapper for
-     * @return Spot\Mapper
+     * @return \Spot\Mapper
      */
     public function mapper($entityName)
     {

--- a/lib/Spot/Mapper.php
+++ b/lib/Spot/Mapper.php
@@ -41,7 +41,7 @@ class Mapper implements MapperInterface
     /**
      * Get config class from locator
      *
-     * @return Spot\Config
+     * @return \Spot\Config
      */
     public function config()
     {
@@ -52,7 +52,7 @@ class Mapper implements MapperInterface
      * Get mapper for specified entity
      *
      * @param  string      $entityName Name of Entity object to load mapper for
-     * @return Spot\Mapper
+     * @return \Spot\Mapper
      */
     public function getMapper($entityName)
     {
@@ -91,6 +91,8 @@ class Mapper implements MapperInterface
 
     /**
      * Entity manager class for storing information and meta-data about entities
+     *
+     * @return \Spot\Entity\Manager
      */
     public function entityManager()
     {
@@ -104,6 +106,8 @@ class Mapper implements MapperInterface
 
     /**
      * Event emitter for this mapper
+     *
+     * @return \Spot\EventEmitter
      */
     public function eventEmitter()
     {
@@ -346,8 +350,8 @@ class Mapper implements MapperInterface
      * Get connection to use
      *
      * @param  string         $connectionName Named connection or entity class name
-     * @return Spot_Adapter
-     * @throws Spot_Exception
+     * @return \Doctrine\DBAL\Connection
+     * @throws \Spot\Exception
      */
     public function connection($connectionName = null)
     {
@@ -532,7 +536,7 @@ class Mapper implements MapperInterface
      * @param  array          $data array of key/values to set on new Entity instance
      * @param  array          $options array of save options that will be passed to insert()
      * @return object         Instance of $entityClass with $data set on it
-     * @throws Spot\Exception
+     * @throws \Spot\Exception
      */
     public function create(array $data, array $options = [])
     {
@@ -641,8 +645,6 @@ class Mapper implements MapperInterface
      */
     public function save(EntityInterface $entity, array $options = [])
     {
-        $eventEmitter = $this->eventEmitter();
-
         // Check entity name
         $entityName = $this->entity();
         if (!($entity instanceof $entityName)) {

--- a/lib/Spot/Relation/HasMany.php
+++ b/lib/Spot/Relation/HasMany.php
@@ -52,9 +52,9 @@ class HasMany extends RelationAbstract implements \Countable, \IteratorAggregate
      * Map relation results to original collection of entities
      *
      * @param string Relation name
-     * @param Spot\Collection Collection of original entities to map results of query back to
+     * @param \Spot\Collection Collection of original entities to map results of query back to
      *
-     * @return Spot\Collection
+     * @return \Spot\Collection
      */
     public function eagerLoadOnCollection($relationName, Collection $collection)
     {

--- a/lib/Spot/Relation/HasManyThrough.php
+++ b/lib/Spot/Relation/HasManyThrough.php
@@ -69,9 +69,9 @@ class HasManyThrough extends RelationAbstract implements \Countable, \IteratorAg
      * Map relation results to original collection of entities
      *
      * @param string Relation name
-     * @param Spot\Collection Collection of original entities to map results of query back to
+     * @param \Spot\Collection Collection of original entities to map results of query back to
      *
-     * @return Spot\Collection
+     * @return \Spot\Collection
      */
     public function eagerLoadOnCollection($relationName, Collection $collection)
     {

--- a/lib/Spot/Relation/RelationAbstract.php
+++ b/lib/Spot/Relation/RelationAbstract.php
@@ -27,7 +27,7 @@ abstract class RelationAbstract
     /**
      * Get Mapper object
      *
-     * @return Spot\Mapper
+     * @return \Spot\Mapper
      */
     public function mapper()
     {
@@ -97,9 +97,9 @@ abstract class RelationAbstract
      * Map relation results to original collection of entities
      *
      * @param string Relation name
-     * @param Spot\Collection Collection of original entities to map results of query back to
+     * @param \Spot\Collection Collection of original entities to map results of query back to
      *
-     * @return Spot\Collection
+     * @return \Spot\Collection
      */
     public function eagerLoadOnCollection($relationName, Collection $collection)
     {


### PR DESCRIPTION
* Replaced `Spot\Classname` with FQCN `\Spot\Classname`
* Replace `Spot_Adapter` with `\Doctrine\DBAL\Connection`

Auto-completion was all messed up when trying to use `$mapper->connection()` so I cleaned-up :-)