### PR TITLE
Add loadRelations option to data/toArray to support limiting depth of to Array

### DIFF
--- a/lib/Spot/Entity.php
+++ b/lib/Spot/Entity.php
@@ -194,9 +194,10 @@ abstract class Entity implements EntityInterface, \JsonSerializable
      *
      * @param null|array $data
      * @param bool $modified
+     * @param boolean $loadRelations Determine if you want to load entity relations
      * @return $this|array|null
      */
-    public function data($data = null, $modified = true)
+    public function data($data = null, $modified = true, $loadRelations = true)
     {
         $entityName = get_class($this);
 
@@ -207,11 +208,17 @@ abstract class Entity implements EntityInterface, \JsonSerializable
                 $v = $this->__get($k, $v);
             }
 
-            foreach (self::$relationFields[$entityName] as $relationField) {
-                $relation = $this->relation($relationField);
+            if ($loadRelations) {
+                foreach (self::$relationFields[$entityName] as $relationField) {
+                    $relation = $this->relation($relationField);
 
-                if ($relation instanceof Entity\Collection || $relation instanceof EntityInterface) {
-                    $data[$relationField] = $relation->toArray();
+                    if ($relation instanceof Entity\Collection) {
+                        $data[$relationField] = $relation->toArray();
+                    }
+
+                    if ($relation instanceof EntityInterface) {
+                        $data[$relationField] = $relation->toArray(false);
+                    }
                 }
             }
 
@@ -325,11 +332,12 @@ abstract class Entity implements EntityInterface, \JsonSerializable
     /**
      * Alias of self::data()
      *
+     * @param boolean $loadRelations Determine if you want to load entity relations
      * @return array
      */
-    public function toArray()
+    public function toArray($loadRelations = true)
     {
-        return $this->data();
+        return $this->data(null, true, $loadRelations);
     }
 
     /**

--- a/lib/Spot/Entity.php
+++ b/lib/Spot/Entity.php
@@ -217,7 +217,7 @@ abstract class Entity implements EntityInterface, \JsonSerializable
                     }
 
                     if ($relation instanceof EntityInterface) {
-                        $data[$relationField] = $relation->toArray(false);
+                        $data[$relationField] = $relation->data(null, $modified, false);
                     }
                 }
             }
@@ -332,12 +332,11 @@ abstract class Entity implements EntityInterface, \JsonSerializable
     /**
      * Alias of self::data()
      *
-     * @param boolean $loadRelations Determine if you want to load entity relations
      * @return array
      */
-    public function toArray($loadRelations = true)
+    public function toArray()
     {
-        return $this->data(null, true, $loadRelations);
+        return $this->data(null, true);
     }
 
     /**


### PR DESCRIPTION
This helps prevent endless loop of loading relationships. It also allows users to specify the depth of the toArray output.