### PR TITLE
Adding PHPUnit to the dev requirements for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
         "doctrine/dbal": "~2.4",
         "sabre/event": "~2.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~4.6"
+    },
     "autoload": {
         "psr-0": {
             "Spot": "lib/"


### PR DESCRIPTION
Spot2 relies on the developer to have phpunit installed globally. This commit adds phpunit via composer.