### PR TITLE
Fix: Direct builds to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 # see http://about.travis-ci.org/docs/user/languages/php/ for more hints
 language: php
 
+sudo: false
+
 # list any PHP version you want to test against
 php:
   - 5.4


### PR DESCRIPTION
This PR

* [x] directs builds to container-based infrastructure

:information_desk_person: Seems like Travis even points this out now, see this

<img width="1066" alt="screen shot 2015-07-09 at 18 02 10" src="https://cloud.githubusercontent.com/assets/605483/8607962/a782d16a-2664-11e5-8845-a007d9e65571.png">

For reference, see http://docs.travis-ci.com/user/migrating-from-legacy.