### PR TITLE
Fix: Cache dependencies installed with Composer between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: php
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 # list any PHP version you want to test against
 php:
   - 5.4


### PR DESCRIPTION
This PR

* [x] enables caching of dependencies installed with Composer between builds on Travis

Follows #101.