### PR TITLE
Fix: Install dependencies in install section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,11 @@ env:
   - SPOT_DB=pgsql
   - SPOT_DB=sqlite
 
+install:
+  - composer install
+
 # execute any number of scripts before the test run, custom env's are available as variables
 before_script:
-  - composer install
   - if [[ "$SPOT_DB" == "mysql" ]]; then mysql -e "create database IF NOT EXISTS spot_test;" -uroot; fi
   - if [[ "$SPOT_DB" == "pgsql" ]]; then psql -c 'create database spot_test;' -U postgres; fi
 


### PR DESCRIPTION
This PR

* [x] moves installation of dependencies with Composer to the `install` section of `.travis.yml`

:information_desk_person: For reference, see [The-Build-Lifecycle](http://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle).