### PR TITLE
Fix: One require-dev section should be enough

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,11 @@
         "sabre/event": "~2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.6"
+        "phpunit/phpunit": "^4.7"
     },
     "autoload": {
         "psr-0": {
             "Spot": "lib/"
         }
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^4.7"
     }
 }


### PR DESCRIPTION
This PR

* [x] removes a duplicate `require-dev` section from `composer.json`