### PR TITLE
Fix: Entity::set() doesn't return anything

### DIFF
--- a/lib/Entity.php
+++ b/lib/Entity.php
@@ -460,7 +460,7 @@ abstract class Entity implements EntityInterface, \JsonSerializable
      */
     public function __set($field, $value)
     {
-        return $this->set($field, $value);
+        $this->set($field, $value);
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] fixes an issue where `Entity::__set()` attempts to return the return value of `Entity::set()`, which doesn't return anything