### PR TITLE
Fix: Entity::__get() only accepts one argument

### DIFF
--- a/lib/Entity.php
+++ b/lib/Entity.php
@@ -205,7 +205,7 @@ abstract class Entity implements EntityInterface, \JsonSerializable
         if (null === $data || !$data) {
             $data = array_merge($this->_data, $this->_dataModified);
             foreach ($data as $k => &$v) {
-                $v = $this->__get($k, $v);
+                $v = $this->__get($k);
             }
 
             if ($loadRelations) {


### PR DESCRIPTION
This PR

* [x] fixes an issue where a second argument is passed to `Entity::__get()`, while the method only accepts one argument