### PR TITLE
Fix #97 with support for field/column aliases

### DIFF
--- a/lib/Entity/Manager.php
+++ b/lib/Entity/Manager.php
@@ -102,7 +102,7 @@ class Manager
 
             // Table Options
             $entityTableOptions = $entityName::tableOptions();
-            $this->tableOptions = (array)$entityTableOptions;
+            $this->tableOptions = (array) $entityTableOptions;
 
             // Custom Mapper
             $this->mapper = $entityName::mapper();
@@ -113,6 +113,7 @@ class Manager
                 'default' => null,
                 'value' => null,
                 'length' => null,
+                'column' => null,
                 'required' => false,
                 'notnull' => false,
                 'unsigned' => false,
@@ -162,6 +163,11 @@ class Manager
                 // Required = 'notnull' for DBAL
                 if (true === $fieldOpts['required']) {
                     $fieldOpts['notnull'] = true;
+                }
+
+                // Set column name to field name/key as default
+                if (null === $fieldOpts['column']) {
+                    $fieldOpts['column'] = $fieldName;
                 }
 
                 // Old Spot used 'serial' field to describe auto-increment
@@ -214,7 +220,9 @@ class Manager
             'index' => []
         ];
         $usedKeyNames = [];
-        foreach ($formattedFields as $fieldName => $fieldInfo) {
+        foreach ($formattedFields as $fieldInfo) {
+            $fieldName = $fieldInfo['column'];
+
             // Determine key field name (can't use same key name twice, so we have to append a number)
             $fieldKeyName = $table . '_' . $fieldName;
             while (in_array($fieldKeyName, $usedKeyNames)) {

--- a/lib/Entity/Manager.php
+++ b/lib/Entity/Manager.php
@@ -24,6 +24,11 @@ class Manager
     /**
      * @var array
      */
+    protected $fieldAliasMappings = [];
+
+    /**
+     * @var array
+     */
     protected $fieldsDefined = [];
 
     /**
@@ -168,6 +173,9 @@ class Manager
                 // Set column name to field name/key as default
                 if (null === $fieldOpts['column']) {
                     $fieldOpts['column'] = $fieldName;
+                } else {
+                    // Store user-specified field alias mapping
+                    $this->fieldAliasMappings[$fieldName] = $fieldOpts['column'];
                 }
 
                 // Old Spot used 'serial' field to describe auto-increment
@@ -199,6 +207,16 @@ class Manager
         }
 
         return $returnFields;
+    }
+
+    /**
+     * Field alias mappings (used for lookup)
+     *
+     * @return array Field alias => actual column name
+     */
+    public function fieldAliasMappings()
+    {
+        return $this->fieldAliasMappings;
     }
 
     /**

--- a/lib/Query.php
+++ b/lib/Query.php
@@ -317,6 +317,7 @@ class Query implements \Countable, \IteratorAggregate, \ArrayAccess
 
         $sqlFragments = [];
         foreach ($where as $column => $value) {
+
             $whereClause = "";
             // Column name with comparison operator
             $colData = explode(' ', $column);
@@ -717,6 +718,13 @@ class Query implements \Countable, \IteratorAggregate, \ArrayAccess
      */
     public function fieldWithAlias($field, $escaped = true)
     {
+        $fieldInfo = $this->_mapper->entityManager()->fields();
+
+        // Determine real field name (column alias support)
+        if (isset($fieldInfo[$field])) {
+            $field = $fieldInfo[$field]['column'];
+        }
+
         $field = $this->_tableName . '.' . $field;
 
         return $escaped ? $this->escapeIdentifier($field) : $field;

--- a/lib/Query/Resolver.php
+++ b/lib/Query/Resolver.php
@@ -156,9 +156,7 @@ class Resolver
     public function create($table, array $data)
     {
         $connection = $this->mapper->connection();
-        $result = $connection->insert($this->escapeIdentifier($table), $data);
-
-        return $result;
+        return $connection->insert($this->escapeIdentifier($table), $this->dataWithFieldAliasMappings($data));
     }
 
     /**
@@ -173,8 +171,21 @@ class Resolver
     public function update($table, array $data, array $where)
     {
         $connection = $this->mapper->connection();
+        return $connection->update($this->escapeIdentifier($table), $this->dataWithFieldAliasMappings($data), $this->dataWithFieldAliasMappings($where));
+    }
 
-        return $connection->update($this->escapeIdentifier($table), $data, $where);
+    /**
+     * Taken given field name/value inputs and map them to their aliased names
+     */
+    public function dataWithFieldAliasMappings(array $data)
+    {
+        $fields = $this->mapper->entityManager()->fields();
+        $fieldMappings = [];
+        foreach($data as $field => $value) {
+            $fieldAlias = $this->escapeIdentifier(isset($fields[$field]) ? $fields[$field]['column'] : $field);
+            $fieldMappings[$fieldAlias] = $value;
+        }
+        return $fieldMappings;
     }
 
     /**

--- a/lib/Query/Resolver.php
+++ b/lib/Query/Resolver.php
@@ -101,23 +101,25 @@ class Resolver
         $schema = new \Doctrine\DBAL\Schema\Schema();
         $table = $schema->createTable($this->escapeIdentifier($table));
 
-        foreach ($fields as $field => $fieldInfo) {
-            $fieldType = $fieldInfo['type'];
-            unset($fieldInfo['type']);
-            $table->addColumn($field, $fieldType, $fieldInfo);
+        foreach ($fields as $field) {
+            $fieldType = $field['type'];
+            unset($field['type']);
+            $table->addColumn($this->escapeIdentifier($field['column']), $fieldType, $field);
         }
 
         // PRIMARY
         if ($fieldIndexes['primary']) {
-            $table->setPrimaryKey($fieldIndexes['primary']);
+            $resolver = $this;
+            $primaryKeys = array_map(function($value) use($resolver) { return $resolver->escapeIdentifier($value); }, $fieldIndexes['primary']);
+            $table->setPrimaryKey($primaryKeys);
         }
         // UNIQUE
         foreach ($fieldIndexes['unique'] as $keyName => $keyFields) {
-            $table->addUniqueIndex($keyFields, $keyName);
+            $table->addUniqueIndex($keyFields, $this->escapeIdentifier($keyName));
         }
         // INDEX
         foreach ($fieldIndexes['index'] as $keyName => $keyFields) {
-            $table->addIndex($keyFields, $keyName);
+            $table->addIndex($keyFields, $this->escapeIdentifier($keyName));
         }
 
         return $schema;

--- a/tests/Entity/Legacy.php
+++ b/tests/Entity/Legacy.php
@@ -25,6 +25,13 @@ class Legacy extends Entity
         ];
     }
 
+    public static function relations(MapperInterface $mapper, EntityInterface $entity)
+    {
+        return [
+            'polymorphic_comments' => $mapper->hasMany($entity, 'SpotTest\Entity\PolymorphicComment', 'item_id')->where(['item_type' => 'legacy'])
+        ];
+    }
+
     /**
      * Helpers for field/column names - methods with public access so we can avoid duplication in tests
      */

--- a/tests/Entity/Legacy.php
+++ b/tests/Entity/Legacy.php
@@ -1,0 +1,50 @@
+<?php
+namespace SpotTest\Entity;
+
+use Spot\Entity;
+use Spot\EntityInterface;
+use Spot\MapperInterface;
+use Spot\EventEmitter;
+
+/**
+ * Legacy - A legacy database table with custom column mappings
+ *
+ * @package Spot
+ */
+class Legacy extends Entity
+{
+    protected static $table = 'test_legacy';
+
+    public static function fields()
+    {
+        return [
+            'id'           => ['type' => 'integer', 'autoincrement' => true, 'primary' => true, 'column' => self::getIdFieldColumnName()],
+            'name'         => ['type' => 'string', 'required' => true, 'column' => self::getNameFieldColumnName()],
+            'number'       => ['type' => 'integer', 'required' => true, 'column' => self::getNumberFieldColumnName()],
+            'date_created' => ['type' => 'datetime', 'value' => new \DateTime(), 'column' => self::getDateCreatedColumnName()],
+        ];
+    }
+
+    /**
+     * Helpers for field/column names - methods with public access so we can avoid duplication in tests
+     */
+    public static function getIdFieldColumnName()
+    {
+        return 'obnoxiouslyObtuse_IdentityColumn';
+    }
+
+    public static function getNameFieldColumnName()
+    {
+        return 'string_54_LegacyDB_x8';
+    }
+
+    public static function getNumberFieldColumnName()
+    {
+        return 'xbf86_haikusInTheDark';
+    }
+
+    public static function getDateCreatedColumnName()
+    {
+        return 'dtCreatedAt';
+    }
+}

--- a/tests/FieldAlias.php
+++ b/tests/FieldAlias.php
@@ -1,5 +1,6 @@
 <?php
 namespace SpotTest;
+use SpotTest\Entity\Legacy;
 
 /**
  * @package Spot
@@ -44,5 +45,41 @@ class FieldAlias extends \PHPUnit_Framework_TestCase
         $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
         $query = $mapper->select()->noQuote()->where(['name' => 'test_group'])->group(['id']);
         $this->assertEquals("SELECT * FROM test_legacy test_legacy WHERE test_legacy." . self::$legacyTable->getNameFieldColumnName() . " = ? GROUP BY test_legacy." . self::$legacyTable->getIdFieldColumnName(), $query->toSql());
+    }
+
+    // Insert
+    public function testLegacyInsert()
+    {
+        $legacy = new Legacy();
+        $legacy->name = 'Something Here';
+        $legacy->number = 5;
+
+        $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
+        $mapper->save($legacy);
+        return $legacy;
+    }
+
+    /**
+     * @depends testLegacyInsert
+     */
+    public function testLegacyUpdate(Legacy $legacy)
+    {
+        $legacy->name = 'Something ELSE Here';
+        $legacy->number = 6;
+
+        $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
+        $mapper->save($legacy);
+    }
+
+    /**
+     * @depends testLegacyInsert
+     */
+    public function testLegacyEntityFieldMapping(Legacy $legacy)
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
+        $savedLegacyItem = $mapper->first();
+
+        $this->assertEquals($legacy->name, $savedLegacyItem->name);
+        $this->assertEquals($legacy->number, $savedLegacyItem->number);
     }
 }

--- a/tests/FieldAlias.php
+++ b/tests/FieldAlias.php
@@ -1,0 +1,48 @@
+<?php
+namespace SpotTest;
+
+/**
+ * @package Spot
+ */
+class FieldAlias extends \PHPUnit_Framework_TestCase
+{
+    public static $legacyTable;
+
+    public static function setupBeforeClass()
+    {
+        self::$legacyTable = new \SpotTest\Entity\Legacy();
+        foreach (['Legacy'] as $entity) {
+            test_spot_mapper('SpotTest\Entity\\' . $entity)->migrate();
+        }
+    }
+
+    public static function tearDownAfterClass()
+    {
+        foreach (['Legacy'] as $entity) {
+            test_spot_mapper('\SpotTest\Entity\\' . $entity)->dropTable();
+        }
+    }
+
+    public function testLegacySelectFieldsAreAliases()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
+        $query = $mapper->select()->noQuote()->where(['number' => 2, 'name' => 'legacy_crud']);
+        $this->assertEquals("SELECT * FROM test_legacy test_legacy WHERE test_legacy." . self::$legacyTable->getNumberFieldColumnName() ." = ? AND test_legacy." . self::$legacyTable->getNameFieldColumnName() . " = ?", $query->toSql());
+    }
+
+    // Ordering
+    public function testLegacyOrderBy()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
+        $query = $mapper->select()->noQuote()->where(['number' => 2])->order(['date_created' => 'ASC']);
+        $this->assertContains("ORDER BY test_legacy." . self::$legacyTable->getDateCreatedColumnName() . " ASC", $query->toSql());
+    }
+
+    // Grouping
+    public function testLegacyGroupBy()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
+        $query = $mapper->select()->noQuote()->where(['name' => 'test_group'])->group(['id']);
+        $this->assertEquals("SELECT * FROM test_legacy test_legacy WHERE test_legacy." . self::$legacyTable->getNameFieldColumnName() . " = ? GROUP BY test_legacy." . self::$legacyTable->getIdFieldColumnName(), $query->toSql());
+    }
+}


### PR DESCRIPTION
Added support for column aliases with the `column` keyword when defining an entity and its fields.