### PR TITLE
Detect modificiations to object and array fields

### DIFF
--- a/lib/Entity.php
+++ b/lib/Entity.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Spot;
 
 /**
@@ -9,6 +10,7 @@ namespace Spot;
  */
 abstract class Entity implements EntityInterface, \JsonSerializable
 {
+
     /**
      * Table name
      * @var string|null
@@ -166,6 +168,7 @@ abstract class Entity implements EntityInterface, \JsonSerializable
      */
     public static function events(EventEmitter $eventEmitter)
     {
+        
     }
 
     /**
@@ -289,7 +292,7 @@ abstract class Entity implements EntityInterface, \JsonSerializable
     public function isNew($new = null)
     {
         if ($new !== null) {
-            $this->_isNew = (boolean)$new;
+            $this->_isNew = (boolean) $new;
         }
 
         return $this->_isNew;
@@ -408,8 +411,7 @@ abstract class Entity implements EntityInterface, \JsonSerializable
     {
         $entityName = get_class($this);
 
-        return isset($this->_data[$key]) || isset($this->_dataModified[$key]) || in_array($key,
-            self::$relationFields[$entityName]);
+        return isset($this->_data[$key]) || isset($this->_dataModified[$key]) || in_array($key, self::$relationFields[$entityName]);
     }
 
     /**
@@ -432,18 +434,21 @@ abstract class Entity implements EntityInterface, \JsonSerializable
         } else {
             // We can't use isset because it returns false for NULL values
             if (array_key_exists($field, $this->_dataModified)) {
-                $v =& $this->_dataModified[$field];
+                $v = & $this->_dataModified[$field];
             } elseif (array_key_exists($field, $this->_data)) {
                 // if the value is an array or an object, copy it to dataModified first 
                 // and return a reference to that
-                if (is_array($this->_data[$field]) || is_object($this->_data[$field])){
-                    $this->_dataModified[$field] = $this->_data[$field]; 
-                    $v =& $this->_dataModified[$field];
+                if (is_array($this->_data[$field])) {
+                    $this->_dataModified[$field] = $this->_data[$field];
+                    $v = & $this->_dataModified[$field];
+                } elseif (is_object($this->_data[$field])) {
+                    $this->_dataModified[$field] = clone $this->_data[$field];
+                    $v = & $this->_dataModified[$field];
                 } else {
-                    $v =& $this->_data[$field];
+                    $v = & $this->_data[$field];
                 }
             } elseif ($relation = $this->relation($field)) {
-                $v =& $relation;
+                $v = & $relation;
             }
         }
 
@@ -613,4 +618,5 @@ abstract class Entity implements EntityInterface, \JsonSerializable
             }
         }
     }
+
 }

--- a/lib/Entity.php
+++ b/lib/Entity.php
@@ -434,7 +434,13 @@ abstract class Entity implements EntityInterface, \JsonSerializable
             if (array_key_exists($field, $this->_dataModified)) {
                 $v =& $this->_dataModified[$field];
             } elseif (array_key_exists($field, $this->_data)) {
-                $v =& $this->_data[$field];
+                // if the value is an array or an object, copy it to dataModified first                
+                if (is_array($this->_data[$field]) || is_object($this->_data[$field])){
+                    $this->_dataModified[$field] = $this->_data[$field]; 
+                    $v =& $this->_dataModified[$field];
+                } else {
+                    $v =& $this->_data[$field];
+                }
             } elseif ($relation = $this->relation($field)) {
                 $v =& $relation;
             }

--- a/lib/Entity.php
+++ b/lib/Entity.php
@@ -434,7 +434,8 @@ abstract class Entity implements EntityInterface, \JsonSerializable
             if (array_key_exists($field, $this->_dataModified)) {
                 $v =& $this->_dataModified[$field];
             } elseif (array_key_exists($field, $this->_data)) {
-                // if the value is an array or an object, copy it to dataModified first                
+                // if the value is an array or an object, copy it to dataModified first 
+                // and return a reference to that
                 if (is_array($this->_data[$field]) || is_object($this->_data[$field])){
                     $this->_dataModified[$field] = $this->_data[$field]; 
                     $v =& $this->_dataModified[$field];

--- a/tests/ArrayObjectTypes.php
+++ b/tests/ArrayObjectTypes.php
@@ -36,7 +36,7 @@ class ArrayObjectTypes extends \PHPUnit_Framework_TestCase
     {
         $entity = $this->getEntity();
         $this->assertFalse($entity->isModified('fld_simple_array'));
-        $entity->fld_array['value'] = 'modified';
+        $entity->fld_simple_array['value'] = 'modified';
         $this->assertTrue($entity->isModified('fld_simple_array'));
     }
 
@@ -44,7 +44,7 @@ class ArrayObjectTypes extends \PHPUnit_Framework_TestCase
     {
         $entity = $this->getEntity();
         $this->assertFalse($entity->isModified('fld_json_array'));
-        $entity->fld_array['value'] = 'modified';
+        $entity->fld_json_array['value'] = 'modified';
         $this->assertTrue($entity->isModified('fld_json_array'));
     }
 
@@ -52,7 +52,7 @@ class ArrayObjectTypes extends \PHPUnit_Framework_TestCase
     {
         $entity = $this->getEntity();
         $this->assertFalse($entity->isModified('fld_object'));
-        $entity->fld_array['value'] = 'modified';
+        $entity->fld_object['value'] = 'modified';
         $this->assertTrue($entity->isModified('fld_object'));
     }
 

--- a/tests/ArrayObjectTypes.php
+++ b/tests/ArrayObjectTypes.php
@@ -52,7 +52,7 @@ class ArrayObjectTypes extends \PHPUnit_Framework_TestCase
     {
         $entity = $this->getEntity();
         $this->assertFalse($entity->isModified('fld_object'));
-        $entity->fld_object['value'] = 'modified';
+        $entity->fld_object->value = 'modified';
         $this->assertTrue($entity->isModified('fld_object'));
     }
 

--- a/tests/ArrayObjectTypes.php
+++ b/tests/ArrayObjectTypes.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace SpotTest;
+
+/**
+ * @package Spot
+ */
+class ArrayObjectTypes extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * The basic entity for these tests
+     * @return \SpotTest\Entity\ArrayObjectType
+     */
+    private function getEntity()
+    {    
+        $entity = new \SpotTest\Entity\ArrayObjectType([
+            'fld_array' => ['value' => 'original'],
+            'fld_simple_array' => ['value' => 'original'],
+            'fld_json_array' => ['value' => 'original'],
+            'fld_object' => (object) ['value' => 'original']
+        ]);
+
+        return $entity;
+    }
+
+    public function testArray()
+    {
+        $entity = $this->getEntity();
+        $this->assertFalse($entity->isModified('fld_array'));
+        $entity->fld_array['value'] = 'modified';
+        $this->assertTrue($entity->isModified('fld_array'));
+    }
+
+    public function testSimpleArray()
+    {
+        $entity = $this->getEntity();
+        $this->assertFalse($entity->isModified('fld_simple_array'));
+        $entity->fld_array['value'] = 'modified';
+        $this->assertTrue($entity->isModified('fld_simple_array'));
+    }
+
+    public function testJsonArray()
+    {
+        $entity = $this->getEntity();
+        $this->assertFalse($entity->isModified('fld_json_array'));
+        $entity->fld_array['value'] = 'modified';
+        $this->assertTrue($entity->isModified('fld_json_array'));
+    }
+
+    public function testObject()
+    {
+        $entity = $this->getEntity();
+        $this->assertFalse($entity->isModified('fld_object'));
+        $entity->fld_array['value'] = 'modified';
+        $this->assertTrue($entity->isModified('fld_object'));
+    }
+
+}

--- a/tests/Entity/ArrayObjectType.php
+++ b/tests/Entity/ArrayObjectType.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SpotTest\Entity;
+
+/**
+ * ArrayObjectType
+ * An entity using all built-in array and object field types
+ *
+ * @package Spot
+ */
+class ArrayObjectType extends \Spot\Entity
+{
+
+    protected static $table = 'test_array_object';
+
+    public static function fields()
+    {
+        return [
+            'id' => ['type' => 'integer', 'primary' => true, 'autoincrement' => true],
+            'fld_array' => ['type' => 'array', 'value' => []],
+            'fld_simple_array' => ['type' => 'simple_array', 'value' => []],
+            'fld_json_array' => ['type' => 'json_array', 'value' => []],
+            'fld_object' => ['type' => 'object', 'value' => new \stdClass()],
+        ];
+    }
+
+}


### PR DESCRIPTION
Modified the getter-code to fix #121 
If the value in the field is an array or an object, __get will always return a reference to the field in Entity::_dataModified. That way Entity::_data stays clean, so any change can be detected afterwards