### PR TITLE
Remove table aliases and allow explicit definition of a schema in Entity class

### DIFF
--- a/lib/Mapper.php
+++ b/lib/Mapper.php
@@ -638,7 +638,7 @@ class Mapper implements MapperInterface
     {
         $table = $this->table();
 
-        return $this->queryBuilder()->select($fields)->from($table, $table);
+        return $this->queryBuilder()->select($fields)->from($table);
     }
 
     /**

--- a/lib/Query/Resolver.php
+++ b/lib/Query/Resolver.php
@@ -115,11 +115,11 @@ class Resolver
         }
         // UNIQUE
         foreach ($fieldIndexes['unique'] as $keyName => $keyFields) {
-            $table->addUniqueIndex($keyFields, $this->escapeIdentifier($keyName));
+            $table->addUniqueIndex($keyFields, $this->escapeIdentifier($this->trimSchemaName($keyName)));
         }
         // INDEX
         foreach ($fieldIndexes['index'] as $keyName => $keyFields) {
-            $table->addIndex($keyFields, $this->escapeIdentifier($keyName));
+            $table->addIndex($keyFields, $this->escapeIdentifier($this->trimSchemaName($keyName)));
         }
 
         return $schema;
@@ -263,4 +263,15 @@ class Resolver
 
         return $this->mapper->connection()->quoteIdentifier(trim($identifier));
     }
+	
+	/**
+	 * Trim a leading schema name separated by a dot if present
+	 *
+	 * @param string $identifier
+	 * @return string
+	 */
+	public function trimSchemaName($identifier){
+		$components = explode('.', $identifier, 2); 
+		return end($components);
+	}
 }

--- a/phpunit_sqlite.xml
+++ b/phpunit_sqlite.xml
@@ -18,6 +18,7 @@
   <testsuites>
     <testsuite name="Spot2 ORM">
       <directory suffix=".php">./tests</directory>
+	  <exclude>./tests/SchemaQuerySql.php</exclude>
     </testsuite>
   </testsuites>
   <filter>

--- a/tests/Entity/Schema/Test.php
+++ b/tests/Entity/Schema/Test.php
@@ -1,0 +1,26 @@
+<?php
+namespace SpotTest\Entity\Schema;
+
+use Spot\Entity;
+use Spot\EntityInterface;
+use Spot\MapperInterface;
+use Spot\EventEmitter;
+
+/**
+ * Post
+ *
+ * @package Spot
+ */
+class Test extends Entity
+{
+    protected static $table = 'spot_test.test_schema_test';
+
+    public static function fields()
+    {
+        return [
+            'id'           => ['type' => 'integer', 'autoincrement' => true, 'primary' => true],
+            'unique'       => ['type' => 'integer', 'default' => 0, 'unique' => true],
+            'index'        => ['type' => 'integer', 'default' => 0, 'index' => true]
+        ];
+    }
+}

--- a/tests/FieldAlias.php
+++ b/tests/FieldAlias.php
@@ -28,7 +28,7 @@ class FieldAlias extends \PHPUnit_Framework_TestCase
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
         $query = $mapper->select()->noQuote()->where(['number' => 2, 'name' => 'legacy_crud']);
-        $this->assertEquals("SELECT * FROM test_legacy WHERE test_legacy." . self::$legacyTable->getNumberFieldColumnName() ." = ? AND test_legacy." . self::$legacyTable->getNameFieldColumnName() . " = ?", $query->toSql());
+        $this->assertEquals("SELECT * FROM test_legacy  WHERE test_legacy." . self::$legacyTable->getNumberFieldColumnName() ." = ? AND test_legacy." . self::$legacyTable->getNameFieldColumnName() . " = ?", $query->toSql());
     }
 
     // Ordering
@@ -44,7 +44,7 @@ class FieldAlias extends \PHPUnit_Framework_TestCase
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
         $query = $mapper->select()->noQuote()->where(['name' => 'test_group'])->group(['id']);
-        $this->assertEquals("SELECT * FROM test_legacy WHERE test_legacy." . self::$legacyTable->getNameFieldColumnName() . " = ? GROUP BY test_legacy." . self::$legacyTable->getIdFieldColumnName(), $query->toSql());
+        $this->assertEquals("SELECT * FROM test_legacy  WHERE test_legacy." . self::$legacyTable->getNameFieldColumnName() . " = ? GROUP BY test_legacy." . self::$legacyTable->getIdFieldColumnName(), $query->toSql());
     }
 
     // Insert

--- a/tests/FieldAlias.php
+++ b/tests/FieldAlias.php
@@ -28,7 +28,7 @@ class FieldAlias extends \PHPUnit_Framework_TestCase
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
         $query = $mapper->select()->noQuote()->where(['number' => 2, 'name' => 'legacy_crud']);
-        $this->assertEquals("SELECT * FROM test_legacy test_legacy WHERE test_legacy." . self::$legacyTable->getNumberFieldColumnName() ." = ? AND test_legacy." . self::$legacyTable->getNameFieldColumnName() . " = ?", $query->toSql());
+        $this->assertEquals("SELECT * FROM test_legacy WHERE test_legacy." . self::$legacyTable->getNumberFieldColumnName() ." = ? AND test_legacy." . self::$legacyTable->getNameFieldColumnName() . " = ?", $query->toSql());
     }
 
     // Ordering
@@ -44,7 +44,7 @@ class FieldAlias extends \PHPUnit_Framework_TestCase
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Legacy');
         $query = $mapper->select()->noQuote()->where(['name' => 'test_group'])->group(['id']);
-        $this->assertEquals("SELECT * FROM test_legacy test_legacy WHERE test_legacy." . self::$legacyTable->getNameFieldColumnName() . " = ? GROUP BY test_legacy." . self::$legacyTable->getIdFieldColumnName(), $query->toSql());
+        $this->assertEquals("SELECT * FROM test_legacy WHERE test_legacy." . self::$legacyTable->getNameFieldColumnName() . " = ? GROUP BY test_legacy." . self::$legacyTable->getIdFieldColumnName(), $query->toSql());
     }
 
     // Insert

--- a/tests/QuerySql.php
+++ b/tests/QuerySql.php
@@ -61,7 +61,7 @@ class QuerySql extends \PHPUnit_Framework_TestCase
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
         $query = $mapper->select()->noQuote()->where(['status' => 2, 'title' => 'even_title']);
-        $this->assertEquals("SELECT * FROM test_posts test_posts WHERE test_posts.status = ? AND test_posts.title = ?", $query->toSql());
+        $this->assertEquals("SELECT * FROM test_posts WHERE test_posts.status = ? AND test_posts.title = ?", $query->toSql());
     }
 
     public function testInsertPostTagWithUniqueConstraint()
@@ -93,7 +93,7 @@ class QuerySql extends \PHPUnit_Framework_TestCase
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
         $query = $mapper->select()->noQuote()->where(['status' => 2]);
-        $this->assertEquals("SELECT * FROM test_posts test_posts WHERE test_posts.status = ?", $query->toSql());
+        $this->assertEquals("SELECT * FROM test_posts WHERE test_posts.status = ?", $query->toSql());
         $this->assertEquals(count($query), 1);
     }
 
@@ -102,7 +102,7 @@ class QuerySql extends \PHPUnit_Framework_TestCase
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
         $query = $mapper->select()->noQuote()->where(['status :eq' => 2]);
-        $this->assertEquals("SELECT * FROM test_posts test_posts WHERE test_posts.status = ?", $query->toSql());
+        $this->assertEquals("SELECT * FROM test_posts WHERE test_posts.status = ?", $query->toSql());
         $this->assertEquals(count($query), 1);
     }
 
@@ -156,7 +156,7 @@ class QuerySql extends \PHPUnit_Framework_TestCase
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
         $query = $mapper->select()->noQuote()->where(['status' => 2])->group(['id']);
-        $this->assertEquals("SELECT * FROM test_posts test_posts WHERE test_posts.status = ? GROUP BY test_posts.id", $query->toSql());
+        $this->assertEquals("SELECT * FROM test_posts WHERE test_posts.status = ? GROUP BY test_posts.id", $query->toSql());
         $this->assertEquals(count($query), 1);
     }
 
@@ -175,7 +175,7 @@ class QuerySql extends \PHPUnit_Framework_TestCase
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
         $query = $mapper->select()->noQuote()->where(['status' => [2]]);
         $post = $query->first();
-        $this->assertEquals("SELECT * FROM test_posts test_posts WHERE test_posts.status IN (?) LIMIT 1", $query->toSql());
+        $this->assertEquals("SELECT * FROM test_posts WHERE test_posts.status IN (?) LIMIT 1", $query->toSql());
         $this->assertEquals(2, $post->status);
     }
 
@@ -404,7 +404,7 @@ class QuerySql extends \PHPUnit_Framework_TestCase
         $expected = str_replace(
             '`',
             $mapper->connection()->getDatabasePlatform()->getIdentifierQuoteCharacter(),
-            'SELECT * FROM `test_posts` `test_posts` WHERE `test_posts`.`title` LIKE ? AND `test_posts`.`status` >= ?'
+            'SELECT * FROM `test_posts` WHERE `test_posts`.`title` LIKE ? AND `test_posts`.`status` >= ?'
         );
 
         $query = $mapper->where(['title :like' => 'lorem', 'status >=' => 1])->toSql();

--- a/tests/QuerySql.php
+++ b/tests/QuerySql.php
@@ -61,7 +61,7 @@ class QuerySql extends \PHPUnit_Framework_TestCase
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
         $query = $mapper->select()->noQuote()->where(['status' => 2, 'title' => 'even_title']);
-        $this->assertEquals("SELECT * FROM test_posts WHERE test_posts.status = ? AND test_posts.title = ?", $query->toSql());
+        $this->assertEquals("SELECT * FROM test_posts  WHERE test_posts.status = ? AND test_posts.title = ?", $query->toSql());
     }
 
     public function testInsertPostTagWithUniqueConstraint()
@@ -93,7 +93,7 @@ class QuerySql extends \PHPUnit_Framework_TestCase
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
         $query = $mapper->select()->noQuote()->where(['status' => 2]);
-        $this->assertEquals("SELECT * FROM test_posts WHERE test_posts.status = ?", $query->toSql());
+        $this->assertEquals("SELECT * FROM test_posts  WHERE test_posts.status = ?", $query->toSql());
         $this->assertEquals(count($query), 1);
     }
 
@@ -102,7 +102,7 @@ class QuerySql extends \PHPUnit_Framework_TestCase
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
         $query = $mapper->select()->noQuote()->where(['status :eq' => 2]);
-        $this->assertEquals("SELECT * FROM test_posts WHERE test_posts.status = ?", $query->toSql());
+        $this->assertEquals("SELECT * FROM test_posts  WHERE test_posts.status = ?", $query->toSql());
         $this->assertEquals(count($query), 1);
     }
 
@@ -156,7 +156,7 @@ class QuerySql extends \PHPUnit_Framework_TestCase
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
         $query = $mapper->select()->noQuote()->where(['status' => 2])->group(['id']);
-        $this->assertEquals("SELECT * FROM test_posts WHERE test_posts.status = ? GROUP BY test_posts.id", $query->toSql());
+        $this->assertEquals("SELECT * FROM test_posts  WHERE test_posts.status = ? GROUP BY test_posts.id", $query->toSql());
         $this->assertEquals(count($query), 1);
     }
 
@@ -175,7 +175,7 @@ class QuerySql extends \PHPUnit_Framework_TestCase
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
         $query = $mapper->select()->noQuote()->where(['status' => [2]]);
         $post = $query->first();
-        $this->assertEquals("SELECT * FROM test_posts WHERE test_posts.status IN (?) LIMIT 1", $query->toSql());
+        $this->assertEquals("SELECT * FROM test_posts  WHERE test_posts.status IN (?) LIMIT 1", $query->toSql());
         $this->assertEquals(2, $post->status);
     }
 

--- a/tests/SchemaQuerySql.php
+++ b/tests/SchemaQuerySql.php
@@ -1,0 +1,67 @@
+<?php
+namespace SpotTest;
+
+/**
+ * @package Spot
+ */
+class SchemaQuerySql extends \PHPUnit_Framework_TestCase
+{
+    public static function setupBeforeClass()
+    {
+        foreach (['Schema\Test'] as $entity) {
+            test_spot_mapper('SpotTest\Entity\\' . $entity)->migrate();
+        }
+
+        // Insert dummy data
+		$entities = [];
+        for ($i = 1; $i <= 10; $i++) {
+            $entities[] = test_spot_mapper('SpotTest\Entity\Schema\Test')->insert([
+                'index' => $i % 5,
+				'unique' => $i * 2
+            ]);
+        }
+    }
+
+    public static function tearDownAfterClass()
+    {
+        foreach (['Schema\Test'] as $entity) {
+            test_spot_mapper('\SpotTest\Entity\\' . $entity)->dropTable();
+        }
+    }
+	
+	// Filtering
+	public function testWhere()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Schema\Test');
+        $query = $mapper->select()->noQuote()->where(['unique' => 6]);
+        $this->assertEquals("SELECT * FROM spot_test.test_schema_test  WHERE spot_test.test_schema_test.unique = ?", $query->toSql());
+    }
+	
+	// Ordering
+    public function testOrderBy()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Schema\Test');
+        $query = $mapper->select()->noQuote()->where(['index' => 2])->order(['unique' => 'ASC']);
+        $this->assertContains("ORDER BY spot_test.test_schema_test.unique ASC", $query->toSql());
+        $this->assertEquals("SELECT * FROM spot_test.test_schema_test  WHERE spot_test.test_schema_test.index = ? ORDER BY spot_test.test_schema_test.unique ASC", $query->toSql());
+    }
+
+	// Identifier quoting
+    public function testQuoting()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Schema\Test');
+
+        $expected = str_replace(
+            '`',
+            $mapper->connection()->getDatabasePlatform()->getIdentifierQuoteCharacter(),
+            'SELECT * FROM `spot_test`.`test_schema_test` WHERE `spot_test`.`test_schema_test`.`index` >= ?'
+        );
+
+        $query = $mapper->where(['index >=' => 2])->toSql();
+
+        $this->assertEquals(
+            $expected,
+            $query
+        );
+    }
+}

--- a/tests/Scopes.php
+++ b/tests/Scopes.php
@@ -24,13 +24,13 @@ class Scopes extends \PHPUnit_Framework_TestCase
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Event');
         $query = $mapper->all()->noQuote()->active();
-        $this->assertEquals("SELECT * FROM test_events WHERE test_events.status = ?", $query->toSql());
+        $this->assertEquals("SELECT * FROM test_events  WHERE test_events.status = ?", $query->toSql());
     }
 
     public function testMultipleScopes()
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Event');
         $query = $mapper->select()->noQuote()->free()->active();
-        $this->assertEquals("SELECT * FROM test_events WHERE (test_events.type = ?) AND (test_events.status = ?)", $query->toSql());
+        $this->assertEquals("SELECT * FROM test_events  WHERE (test_events.type = ?) AND (test_events.status = ?)", $query->toSql());
     }
 }

--- a/tests/Scopes.php
+++ b/tests/Scopes.php
@@ -24,13 +24,13 @@ class Scopes extends \PHPUnit_Framework_TestCase
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Event');
         $query = $mapper->all()->noQuote()->active();
-        $this->assertEquals("SELECT * FROM test_events test_events WHERE test_events.status = ?", $query->toSql());
+        $this->assertEquals("SELECT * FROM test_events WHERE test_events.status = ?", $query->toSql());
     }
 
     public function testMultipleScopes()
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Event');
         $query = $mapper->select()->noQuote()->free()->active();
-        $this->assertEquals("SELECT * FROM test_events test_events WHERE (test_events.type = ?) AND (test_events.status = ?)", $query->toSql());
+        $this->assertEquals("SELECT * FROM test_events WHERE (test_events.type = ?) AND (test_events.status = ?)", $query->toSql());
     }
 }


### PR DESCRIPTION
This pull request implements the feature requested in issue #126.

The schema (a.k.a. database) in which an entity table should be can be explicitly defined in an Entity class:

    protected static $table = 'support.tickets'; // Schema `support`, `table tickets`

- Existing unit tests have been adapted to the new SQL statements.
- There is also a new test `SchemaQuerySql` using a new Entity `Schema\Test` to test this feature with and without quoting identifiers.
- This test is excluded from `phpunit_sqlite.xml` because this implementation does not work in SQLite.
- All MySQL and SQLite tests pass - could not test for PostgreSQL.