### PR TITLE
Honor given notnull setting in schema even if required setting is true

### DIFF
--- a/lib/Entity/Manager.php
+++ b/lib/Entity/Manager.php
@@ -165,9 +165,14 @@ class Manager
                     $fieldOpts = array_merge($fieldDefaults, $fieldOpts);
                 }
 
-                // Required = 'notnull' for DBAL
+                // Required = 'notnull' for DBAL unless manually set in schema
                 if (true === $fieldOpts['required']) {
-                    $fieldOpts['notnull'] = true;
+                    // If notnull is set in schema use it
+                    if (isset($this->fieldsDefined[$fieldName]['notnull'])) {
+                        $fieldOpts['notnull'] = $this->fieldsDefined[$fieldName]['notnull'];
+                    } else {
+                        $fieldOpts['notnull'] = true;
+                    }
                 }
 
                 // Set column name to field name/key as default

--- a/tests/Entity/NotNullOverride.php
+++ b/tests/Entity/NotNullOverride.php
@@ -1,0 +1,24 @@
+<?php
+namespace SpotTest\Entity;
+
+use Spot\Entity;
+
+/**
+ * Entity with no serial/autoincrement
+ *
+ * @package Spot
+ */
+class NotNullOverride extends \Spot\Entity
+{
+    protected static $table = 'test_notnulloverride';
+
+    public static function fields()
+    {
+        return [
+            'id'     => ['type' => 'integer', 'primary' => true],
+            'data1'  => ['type' => 'string', 'required' => true],
+            'data2'  => ['type' => 'string', 'required' => true, 'notnull' => true],
+            'data3'  => ['type' => 'string', 'required' => true, 'notnull' => false],
+        ];
+    }
+}

--- a/tests/Manager.php
+++ b/tests/Manager.php
@@ -1,0 +1,19 @@
+<?php
+namespace SpotTest;
+
+/**
+ * @package Spot
+ */
+class Manager extends \PHPUnit_Framework_TestCase
+{
+    public function testNotnullOverride()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\NotNullOverride');
+        $manager = $mapper->entityManager();
+        $fields = $manager->fields();
+
+        $this->assertTrue($fields['data1']['notnull']); // Should default to true
+        $this->assertTrue($fields['data2']['notnull']); // Should override to true
+        $this->assertFalse($fields['data3']['notnull']); // Should override to false
+    }
+}


### PR DESCRIPTION
Currently if you have fields defined as below `notnull` will be `true` for all data columns. This is because `required` causes `notnull` default to `true`. You should however be able to manually set `notnull` to be `false` if you know what you are doing.

```php
public static function fields()
{
    return [
        "id"     => ["type" => "integer", "primary" => true],
        "data1"  => ["type" => "string", "required" => true],
        "data2"  => ["type" => "string", "required" => true, "notnull" => true],
        "data3"  => ["type" => "string", "required" => true, "notnull" => false],
    ];
}
```

This pull request changes the behaviour so that `required` setting wont override user provided `notnull` setting when present.