### PR TITLE
Run count(*) queries when counting relations instead of eager loading all entities

### DIFF
--- a/lib/Relation/HasMany.php
+++ b/lib/Relation/HasMany.php
@@ -94,7 +94,12 @@ class HasMany extends RelationAbstract implements \Countable, \IteratorAggregate
      */
     public function count()
     {
-        return $this->query()->count();
+        if ($this->result === null) {
+            $count = $this->query()->count();
+        } else {
+            $count = count($this->result);
+        }
+        return $count;
     }
 
     /**

--- a/lib/Relation/HasMany.php
+++ b/lib/Relation/HasMany.php
@@ -94,9 +94,7 @@ class HasMany extends RelationAbstract implements \Countable, \IteratorAggregate
      */
     public function count()
     {
-        $results = $this->execute();
-
-        return $results ? count($results) : 0;
+        return $this->query()->count();
     }
 
     /**

--- a/lib/Relation/HasManyThrough.php
+++ b/lib/Relation/HasManyThrough.php
@@ -132,7 +132,12 @@ class HasManyThrough extends RelationAbstract implements \Countable, \IteratorAg
      */
     public function count()
     {
-        return $this->query()->count();
+        if ($this->result === null) {
+            $count = $this->query()->count();
+        } else {
+            $count = count($this->result);
+        }
+        return $count;
     }
 
     /**

--- a/lib/Relation/HasManyThrough.php
+++ b/lib/Relation/HasManyThrough.php
@@ -132,9 +132,7 @@ class HasManyThrough extends RelationAbstract implements \Countable, \IteratorAg
      */
     public function count()
     {
-        $results = $this->execute();
-
-        return $results ? count($results) : 0;
+        return $this->query()->count();
     }
 
     /**


### PR DESCRIPTION
As the title says. A simple solution for the case when you might have a lot of related entities and you only want to display a count of them. Also makes the relations behavior consistent with the entities themselves, as $comments->count() already created a count(*) style query, while $article->getComments()->count() loaded all related data and populated all entities, which isn't really intuitive and quite of an overkill when all you want to do is displaying a counter.