### PR TITLE
Bugfix Mapper does not validate not required fields

### DIFF
--- a/lib/Mapper.php
+++ b/lib/Mapper.php
@@ -1043,7 +1043,7 @@ class Mapper implements MapperInterface
             }
 
             // Run only if field required
-            if ($entity->$field !== null && $fieldAttrs['required'] === true) {
+            if ($entity->$field !== null || $fieldAttrs['required'] === true) {
                 // Field with 'options'
                 if (isset($fieldAttrs['options']) && is_array($fieldAttrs['options'])) {
                     $v->rule('in', $field, $fieldAttrs['options']);


### PR DESCRIPTION
It is a pull request regarding the issue #78. I made the change, but a test is failing and I want your advice on how to go about it.

The test that is failing is \SpotTest\Relations::testEventInsert, [line 209](https://github.com/vlucas/spot2/blob/master/tests/Relations.php#L209). It fails because the entity does not validate anymore, the error is Status contains invalid value. The value is `(int) 1` which is the default value for the Event entity, but the options are defined as an associative array: 

```
[
    0 => 'Inactive',
    1 => 'Active',
    2 => 'Archived'
 ]
```

But Valitron seems to be looking at the names and not the keys...

We could force array_keys, but there might be people using numeric arrays, or maybe options should only support numeric arrays to prevent validation errors and work better with Valitron and so the default in [Event->status](https://github.com/vlucas/spot2/blob/master/tests/Entity/Event.php#L35) should be changed to 'Active'
