### PR TITLE
Scopes enhancements

### DIFF
--- a/lib/Mapper.php
+++ b/lib/Mapper.php
@@ -288,7 +288,8 @@ class Mapper implements MapperInterface
      */
     public function scopes()
     {
-        return [];
+        $entityClass = $this->entityName;
+        return $entityClass::scopes();
     }
 
     /**

--- a/lib/Relation/RelationAbstract.php
+++ b/lib/Relation/RelationAbstract.php
@@ -169,7 +169,7 @@ abstract class RelationAbstract
      */
     public function __call($func, $args)
     {
-        if (method_exists('Spot\Query', $func)) {
+        if (method_exists('Spot\Query', $func) || in_array($func, array_keys($this->mapper()->getMapper($this->entityName())->scopes()))) {
             // See if method exists on Query object, and if it does, add query
             // modification to queue to be executed after query is built and
             // ready so that query is not executed immediately

--- a/tests/Entity/Post.php
+++ b/tests/Entity/Post.php
@@ -5,6 +5,7 @@ use Spot\Entity;
 use Spot\EntityInterface;
 use Spot\MapperInterface;
 use Spot\EventEmitter;
+use Spot\Query;
 
 /**
  * Post
@@ -53,6 +54,15 @@ class Post extends Entity
                 }
             });
         }
+    }
+
+    public static function scopes()
+    {
+        return [
+            'active' => function (Query $query) {
+                return $query->where(['status' => 1]);
+            }
+        ];
     }
 
     public function mock_save_hook()

--- a/tests/Entity/Post/Comment.php
+++ b/tests/Entity/Post/Comment.php
@@ -1,8 +1,10 @@
 <?php
 namespace SpotTest\Entity\Post;
 
-use Spot\MapperInterface;
+use DateTime;
+use Spot\Entity;
 use Spot\EntityInterface;
+use Spot\MapperInterface;
 use Spot\Query;
 
 /**
@@ -10,7 +12,7 @@ use Spot\Query;
  *
  * @package Spot
  */
-class Comment extends \Spot\Entity
+class Comment extends Entity
 {
     protected static $table = 'test_post_comments';
 
@@ -30,7 +32,7 @@ class Comment extends \Spot\Entity
     {
         return [
             'yesterday' => function (Query $query) {
-                return $query->where(['date_created :gt' => date('Y-m-d H:i:s', strtotime('yesterday')), 'date_created :lt' => date('Y-m-d H:i:s', strtotime('today'))]);
+                return $query->where(['date_created :gt' => new DateTime('yesterday'), 'date_created :lt' => new DateTime('today')]);
             }
         ];
     }

--- a/tests/Entity/Post/Comment.php
+++ b/tests/Entity/Post/Comment.php
@@ -3,6 +3,7 @@ namespace SpotTest\Entity\Post;
 
 use Spot\MapperInterface;
 use Spot\EntityInterface;
+use Spot\Query;
 
 /**
  * Post Comment
@@ -24,6 +25,16 @@ class Comment extends \Spot\Entity
             'date_created'  => ['type' => 'datetime']
         ];
     }
+
+    public static function scopes()
+    {
+        return [
+            'yesterday' => function (Query $query) {
+                return $query->where(['date_created :gt' => date('Y-m-d H:i:s', strtotime('yesterday')), 'date_created :lt' => date('Y-m-d H:i:s', strtotime('today'))]);
+            }
+        ];
+    }
+
 
     public static function relations(MapperInterface $mapper, EntityInterface $entity)
     {

--- a/tests/Scopes.php
+++ b/tests/Scopes.php
@@ -50,6 +50,7 @@ class Scopes extends \PHPUnit_Framework_TestCase
             'author_id' => 1,
             ]);
         $query = $mapper->get(1)->comments->yesterday()->query();
-        $this->assertEquals("SELECT * FROM `test_post_comments` WHERE (`test_post_comments`.`post_id` = ?) AND (`test_post_comments`.`date_created` > ? AND `test_post_comments`.`date_created` < ?) ORDER BY `test_post_comments`.`date_created` ASC", $query->toSql());
+        $sql = str_replace(['`', '"'], '', $query->toSql());
+        $this->assertEquals("SELECT * FROM test_post_comments WHERE (test_post_comments.post_id = ?) AND (test_post_comments.date_created > ? AND test_post_comments.date_created < ?) ORDER BY test_post_comments.date_created ASC", $sql);
     }
 }

--- a/tests/Scopes.php
+++ b/tests/Scopes.php
@@ -33,4 +33,23 @@ class Scopes extends \PHPUnit_Framework_TestCase
         $query = $mapper->select()->noQuote()->free()->active();
         $this->assertEquals("SELECT * FROM test_events  WHERE (test_events.type = ?) AND (test_events.status = ?)", $query->toSql());
     }
+
+    public function testEntityScopes()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Post');
+        $query = $mapper->select()->noQuote()->active();
+        $this->assertEquals("SELECT * FROM test_posts  WHERE test_posts.status = ?", $query->toSql());
+    }
+
+    public function testRelationScopes()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Post');
+        $mapper->insert([
+            'title' => 'Test',
+            'body' => 'Test body',
+            'author_id' => 1,
+            ]);
+        $query = $mapper->get(1)->comments->yesterday()->query();
+        $this->assertEquals("SELECT * FROM `test_post_comments` WHERE (`test_post_comments`.`post_id` = ?) AND (`test_post_comments`.`date_created` > ? AND `test_post_comments`.`date_created` < ?) ORDER BY `test_post_comments`.`date_created` ASC", $query->toSql());
+    }
 }


### PR DESCRIPTION
Mapper now defaults to entities' scopes instead of empty array. The method `scopes` was already defined in Entity, but I don't think it was used from what I saw in the code. 

Scopes can be used from relations:
```
//Get post with id 1, then its comments, then just yesterday's.
$yesterday_comments = $mapper->get(1)->comments->yesterday();
```