### PR TITLE
Added foreign keys from BelongsTo relations to the table schema #77

### DIFF
--- a/lib/Entity/Manager.php
+++ b/lib/Entity/Manager.php
@@ -127,7 +127,7 @@ class Manager
                 'index' => false,
                 'unique' => false,
                 'autoincrement' => false,
-                'foreignkey' => false,
+                'foreignkey' => true,
                 'onUpdate' => null,
                 'onDelete' => null
             ];

--- a/lib/Entity/Manager.php
+++ b/lib/Entity/Manager.php
@@ -126,7 +126,10 @@ class Manager
                 'primary' => false,
                 'index' => false,
                 'unique' => false,
-                'autoincrement' => false
+                'autoincrement' => false,
+                'foreignkey' => false,
+                'onUpdate' => null,
+                'onDelete' => null
             ];
 
             // Type default overrides for specific field types

--- a/lib/Query/Resolver.php
+++ b/lib/Query/Resolver.php
@@ -303,7 +303,7 @@ class Resolver
 
                 if (!is_null($fieldInfo['onDelete'])) {
                     $onDelete = $fieldInfo['onDelete'];
-                } else if ($fieldInfo['required']) {
+                } else if ($fieldInfo['notnull']) {
                     $onDelete = "CASCADE";
                 } else {
                     $onDelete = "SET NULL";

--- a/lib/Query/Resolver.php
+++ b/lib/Query/Resolver.php
@@ -3,6 +3,8 @@ namespace Spot\Query;
 
 use Spot\Mapper;
 use Spot\Query;
+use Doctrine\DBAL\Schema\Table;
+use Spot\Relation\BelongsTo;
 
 /**
  * Main query resolver
@@ -121,6 +123,8 @@ class Resolver
         foreach ($fieldIndexes['index'] as $keyName => $keyFields) {
             $table->addIndex($keyFields, $this->escapeIdentifier($this->trimSchemaName($keyName)));
         }
+        // FOREIGN KEYS
+        $this->addForeignKeys($table);
 
         return $schema;
     }
@@ -264,14 +268,52 @@ class Resolver
         return $this->mapper->connection()->quoteIdentifier(trim($identifier));
     }
 	
-	/**
-	 * Trim a leading schema name separated by a dot if present
-	 *
-	 * @param string $identifier
-	 * @return string
-	 */
-	public function trimSchemaName($identifier){
-		$components = explode('.', $identifier, 2); 
-		return end($components);
-	}
+    /**
+     * Trim a leading schema name separated by a dot if present
+     *
+     * @param string $identifier
+     * @return string
+     */
+    public function trimSchemaName($identifier){
+            $components = explode('.', $identifier, 2);
+            return end($components);
+    }
+
+    /**
+     * Add foreign keys from BelongsTo relations to the table schema
+     * @param Table $table
+     * @return Table
+     */
+    protected function addForeignKeys(Table $table)
+    {
+        $relations = $this->mapper->entityManager()->relations();
+        $fields = $this->mapper->entityManager()->fields();
+        foreach ($relations as $relationName => $relation) {
+            if ($relation instanceof BelongsTo) {
+
+                $fieldInfo = $fields[$relation->localKey()];
+
+                if ($fieldInfo['foreignkey'] === false) {
+                    continue;
+                }
+
+                $foreignTable = $relation->mapper()->getMapper($relation->entityName())->table();
+
+                $onUpdate = !is_null($fieldInfo['onUpdate']) ? $fieldInfo['onUpdate'] :"CASCADE";
+
+                if (!is_null($fieldInfo['onDelete'])) {
+                    $onDelete = $fieldInfo['onDelete'];
+                } else if ($fieldInfo['required']) {
+                    $onDelete = "CASCADE";
+                } else {
+                    $onDelete = "SET NULL";
+                }
+
+                $fkName = $this->mapper->table().'_fk_'.$relationName;
+                $table->addForeignKeyConstraint($foreignTable, [$relation->localKey()], [$relation->foreignKey()], ["onDelete" => $onDelete, "onUpdate" => $onUpdate], $fkName);
+            }
+        }
+
+        return $table;
+    }
 }


### PR DESCRIPTION
Pull request to add foreign keys  (#77).

Adds the following options to the fields configuration:

- `foreignkey`: Defaults to false. If set to true, the foreign key will be added in migrations
- `onUpdate`: Defaults to null, valid options are: CASCADE, SET NULL, RESTRICT, NO ACTION. When left to null, it will be set to CASCADE during migration.
- `onDelete`: Defaults to null, valid options are: CASCADE, SET NULL, RESTRICT, NO ACTION. When left to null, it will be set to CASCADE if the field is `required`, else it will be SET NULL

I added `foreignkey` to prevent any regression from scripts that might behave inconsistently with the `onUpdate` and `onDelete` defaults.