### PR TITLE
Save relations

### DIFF
--- a/lib/Mapper.php
+++ b/lib/Mapper.php
@@ -764,7 +764,7 @@ class Mapper implements MapperInterface
             // Update primary key on entity object
             $entity->$pkField = $result;
             $entity->isNew(false);
-            $entity->data($entity->data(), false);
+            $entity->data($entity->data(null, true, false), false);
 
             if (isset($options['relations']) && $options['relations'] === true) {
                 $this->saveHasRelations($entity, $options);
@@ -835,7 +835,7 @@ class Mapper implements MapperInterface
 
         if (count($data) > 0) {
             $result = $this->resolver()->update($this->table(), $data, [$this->primaryKeyField() => $this->primaryKey($entity)]);
-            $entity->data($entity->data(), false);
+            $entity->data($entity->data(null, true, false), false);
             if (isset($options['relations']) && $options['relations'] === true) {
                 $this->saveHasRelations($entity, $options);
             }

--- a/lib/Mapper.php
+++ b/lib/Mapper.php
@@ -907,40 +907,82 @@ class Mapper implements MapperInterface
         foreach ($relations as $relationName => $relation) {
             if ($relation instanceof Relation\HasManyThrough) {
                 $relatedEntities = $entity->relation($relationName);
+                $oldEntities = $relation->execute();
                 if (is_array($relatedEntities) || $relatedEntities instanceof Entity\Collection) {
                     $throughMapper = $this->getMapper($relation->throughEntityName());
                     $relatedMapper = $this->getMapper($relation->entityName());
+                    $relatedIds = [];
                     foreach ($relatedEntities as $related) {
                         if ($related->isNew() || $related->isModified()) {
                             $lastResult = $relatedMapper->save($related, $options);
                         }
+                        $relatedIds[] = $related->primaryKey();
                         if (!count($throughMapper->where([$relation->localKey() => $entity->primaryKey(), $relation->foreignKey() => $related->primaryKey()]))) {
                             $lastResult = $throughMapper->create([$relation->localKey() => $entity->primaryKey(), $relation->foreignKey() => $related->primaryKey()]);
                         }
                     }
+                    $deletedIds = [];
+                    foreach ($oldEntities as $oldRelatedEntity) {
+                        if (!in_array($oldRelatedEntity, $relatedIds)) {
+                            $deletedIds[] = $oldRelatedEntity->primaryKey();
+                        }
+                    }
+                    if (!empty($deletedIds)) {
+                        $throughMapper->delete([$relation->localKey() => $entity->primaryKey(), $relation->foreignKey().' :in' => $deletedIds]);
+                    }
+                } else if ($relatedEntities === false) {
+                    //Relation was deleted, remove all
+                    $throughMapper = $this->getMapper($relation->throughEntityName());
+                    $throughMapper->delete([$relation->localKey() => $entity->primaryKey()]);
                 }
             } else if ($relation instanceof Relation\HasMany) {
                 $relatedEntities = $entity->relation($relationName);
+                $deletedIds = [];
+                $relatedMapper = $this->getMapper($relation->entityName());
                 if (is_array($relatedEntities) || $relatedEntities instanceof Entity\Collection) {
-                    $relatedMapper = $this->getMapper($relation->entityName());
+                    $oldEntities = $relation->execute();
+                    $relatedIds = [];
                     foreach ($relatedEntities as $related) {
                         if ($related->isNew() || $related->isModified()) {
                             //Update the foreign key to match the main entity primary key
                             $related->set($relation->foreignKey(), $entity->primaryKey());
                             $lastResult = $relatedMapper->save($related, $options);
                         }
+                        $relatedIds[] = $related->id;
+                    }
+
+                    foreach ($oldEntities as $oldRelatedEntity) {
+                        if (!in_array($oldRelatedEntity, $relatedIds)) {
+                            $deletedIds[] = $oldRelatedEntity->primaryKey();
+                        }
+                    }
+                }
+                if (count($deletedIds) || $relatedEntities === false) {
+                    $conditions = [$relation->foreignKey() => $entity->primaryKey()];
+                    if (count($deletedIds)) {
+                        $conditions[$relation->localKey().' :in'] = $deletedIds;
+                    }
+                    if ($relatedMapper->entityManager()->fields()[$relation->foreignKey()]['notnull']) {
+                        $relatedMapper->delete($conditions);
+                    } else {
+                        $relatedMapper->queryBuilder()->builder()->update($relatedMapper->table())->set($relation->foreignKey(), null)->where($conditions);
                     }
                 }
             } else if ($relation instanceof Relation\HasOne) {
                 $relatedEntity = $entity->relation($relationName);
-                if ($relatedEntity instanceof EntityInterface) {
-                    if ($relatedEntity->isNew() || $relatedEntity->isModified()) {
-                        $relatedMapper = $this->getMapper($relation->entityName());
-                        //Update the foreign key to match the main entity primary key
-                        $relatedEntity->set($relation->foreignKey(), $entity->primaryKey());
-                        $lastResult = $relatedMapper->save($relatedEntity, $options);
+                $relatedMapper = $this->getMapper($relation->entityName());
+                if ($relatedEntity === false || $relation->{$relatedEntity->primaryKeyField()} !== $relatedEntity->primaryKey()) {
+                    if ($relatedMapper->entityManager()->fields()[$relation->foreignKey()]['notnull']) {
+                        $relatedMapper->delete([$relation->foreignKey() => $entity->primaryKey()]);
+                    } else {
+                        $relatedMapper->upsert([$relation->foreignKey() => null], [$relation->foreignKey() => $entity->primaryKey()]);
                     }
                 }
+                if ($relatedEntity instanceof EntityInterface && ($relatedEntity->isNew() || $relatedEntity->isModified())) {
+                    //Update the foreign key to match the main entity primary key
+                    $relatedEntity->set($relation->foreignKey(), $entity->primaryKey());
+                    $lastResult = $relatedMapper->save($relatedEntity, $options);
+                } 
             }
         }
 
@@ -967,9 +1009,23 @@ class Mapper implements MapperInterface
                 if ($relatedEntity instanceof EntityInterface) {
                     if ($relatedEntity->isNew() || $relatedEntity->isModified()) {
                         $relatedMapper = $this->getMapper($relation->entityName());
+
                         $lastResult = $relatedMapper->save($relatedEntity, $options);
                          //Update the local key to match the related entity primary key
                         if ($entity->get($relation->localKey()) !== $relatedEntity->primaryKey()) {
+                            $relatedRelations = $entity->relations($relatedMapper, $relatedEntity);
+
+                            //Check if it was a hasOne or a hasMany relation,
+                            //if hasOne, we must unset old value
+                            foreach ($relatedRelations as $relatedRelation) {
+                                if ($relatedRelation instanceof Relation\HasOne && $relatedRelation->foreignKey() === $relation->localKey()) {
+                                    if ($relatedMapper->entityManager()->fields()[$relatedRelation->foreignKey()]['notnull']) {
+                                        $relatedMapper->delete([$relatedRelation->foreignKey() => $entity->get($relatedRelation->foreignKey())]);
+                                    } else {
+                                        $relatedMapper->upsert([$relatedRelation->foreignKey() => null], [$relatedRelation->foreignKey() => $entity->get($relatedRelation->foreignKey())]);
+                                    }
+                                }
+                            }
                             $entity->set($relation->localKey(), $relatedEntity->primaryKey());
                         }
                     }

--- a/lib/Relation/HasOne.php
+++ b/lib/Relation/HasOne.php
@@ -2,6 +2,7 @@
 namespace Spot\Relation;
 
 use Spot\Mapper;
+use Spot\EntityInterface;
 use Spot\Entity\Collection;
 
 /**
@@ -69,6 +70,35 @@ class HasOne extends RelationAbstract implements \ArrayAccess
     public function entity()
     {
         return $this->execute();
+    }
+
+    /**
+     * Save related entities
+     *
+     * @param EntityInterface $entity Entity to save relation from
+     * @param string $relationName Name of the relation to save
+     * @param array $options Options to pass to the mappers
+     * @return boolean
+     */
+    public function save(EntityInterface $entity, $relationName, $options = [])
+    {
+        $lastResult = false;
+        $relatedEntity = $entity->relation($relationName);
+        $relatedMapper = $this->mapper()->getMapper($this->entityName());
+        if ($relatedEntity === false || $this->{$relatedEntity->primaryKeyField()} !== $relatedEntity->primaryKey()) {
+            if ($relatedMapper->entityManager()->fields()[$this->foreignKey()]['notnull']) {
+                $relatedMapper->delete([$this->foreignKey() => $entity->primaryKey()]);
+            } else {
+                $relatedMapper->upsert([$this->foreignKey() => null], [$this->foreignKey() => $entity->primaryKey()]);
+            }
+        }
+        if ($relatedEntity instanceof EntityInterface && ($relatedEntity->isNew() || $relatedEntity->isModified())) {
+            //Update the foreign key to match the main entity primary key
+            $relatedEntity->set($this->foreignKey(), $entity->primaryKey());
+            $lastResult = $relatedMapper->save($relatedEntity, $options);
+        }
+
+        return $lastResult;
     }
 
     // Magic getter/setter passthru

--- a/lib/Relation/RelationAbstract.php
+++ b/lib/Relation/RelationAbstract.php
@@ -2,7 +2,7 @@
 namespace Spot\Relation;
 
 use Spot\Query;
-use Spot\Entity;
+use Spot\EntityInterface;
 use Spot\Entity\Collection;
 
 /**
@@ -165,6 +165,16 @@ abstract class RelationAbstract
     }
 
     /**
+     * Save related entities
+     *
+     * @param EntityInterface $entity Entity to save relation from
+     * @param string $relationName Name of the relation to save
+     * @param array $options Options to pass to the mappers
+     * @return boolean
+     */
+    abstract public function save(EntityInterface $entity, $relationName, $options = []);
+
+    /**
      * Passthrough for missing methods on expected object result
      */
     public function __call($func, $args)
@@ -186,7 +196,7 @@ abstract class RelationAbstract
                 return call_user_func_array([$result, $func], $args);
             }
 
-            throw new \BadMethodCallException("Method " . get_called_class() . "::$func does not exist");
+            throw new BadMethodCallException("Method " . get_called_class() . "::$func does not exist");
         }
     }
 }

--- a/tests/CRUD.php
+++ b/tests/CRUD.php
@@ -275,7 +275,7 @@ class CRUD extends \PHPUnit_Framework_TestCase
         $result = $postMapper->save($post, ['strict' => false]);
         $this->assertTrue((boolean) $result);
     }
-
+    
     public function testHasOneRelationValidation()
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Event');
@@ -299,7 +299,9 @@ class CRUD extends \PHPUnit_Framework_TestCase
         $event->relation('search', $search2);
         $mapper->save($event, ['relations' => true]);
         
-        $this->assertEquals($searchMapper->get($search->primaryKey()), false);
+        $queryHasOne = $searchMapper->where(['event_id' => $event->id]);
+        $this->assertEquals(count($queryHasOne), 1);
+        $this->assertEquals($queryHasOne->first()->get('body'), 'body2');
     }
 
     public function testBelongsToRelationValidation()

--- a/tests/Validation.php
+++ b/tests/Validation.php
@@ -104,4 +104,48 @@ class Test_Validation extends PHPUnit_Framework_TestCase
 
         $this->assertFalse($entity->hasErrors());
     }
+
+    public function testHasOneRelationValidation()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Event');
+        $search = new SpotTest\Entity\Event\Search();
+        $event = $mapper->build([]);
+        $event->relation('search', $search);
+        $mapper->validate($event, ['relations' => true]);
+
+        $this->assertTrue(isset($event->errors()['search']));
+    }
+
+    public function testBelongsToRelationValidation()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Post');
+        $author = new SpotTest\Entity\Author();
+        $post = $mapper->build([]);
+        $post->relation('author', $author);
+        $mapper->validate($post, ['relations' => true]);
+
+        $this->assertTrue(isset($post->errors()['author']));
+    }
+
+    public function testHasManyRelationValidation()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Post');
+        $comment = new SpotTest\Entity\Post\Comment();
+        $post = $mapper->build([]);
+        $post->relation('comments', new \Spot\Entity\Collection([$comment]));
+        $mapper->validate($post, ['relations' => true]);
+
+        $this->assertTrue(isset($post->errors()['comments'][0]));
+    }
+
+    public function testHasManyThroughRelationValidation()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\Post');
+        $tag = new SpotTest\Entity\Tag();
+        $post = $mapper->build([]);
+        $post->relation('tags', new \Spot\Entity\Collection([$tag]));
+        $mapper->validate($post, ['relations' => true]);
+
+        $this->assertTrue(isset($post->errors()['tags'][0]));
+    }
 }


### PR DESCRIPTION
Enables automatically saving relations when saving an entity.

Will only save loaded or explicitly set relations. It won't bother with lazy loaded relations as they have not been modified and do not need to be saved.

Adds a new option when saving to keep backward compatibility: `relations`, if set to true, all related entities will be saved at the same time as the entity.

The same option can be used with validation. So you can validate an entire tree of entities in one call.
The main entity will have the errors of all related entities under a key named from the relation name.

Example from the tests:

```php
$author = new \SpotTest\Entity\Author(['email' => 'test@example.com', 'password' => '123456']);
$post = $mapper->build([
     'title' => 'Test',
    'body' => 'Test description',
]);
$post->relation('author', $author);
$mapper->save($post, ['relations' => true]);

```