### PR TITLE
Changed order in set to match the order of get (dataModified, data, relation)

### DIFF
--- a/lib/Entity.php
+++ b/lib/Entity.php
@@ -491,13 +491,15 @@ abstract class Entity implements EntityInterface, \JsonSerializable
             unset($this->_inSetter[$field]);
         }
 
-        if (in_array($field, self::$relationFields[get_class($this)])) {
+        if (array_key_exists($field, $this->_data) || !in_array($field, self::$relationFields[get_class($this)])) {
+            if ($modified) {
+                $this->_dataModified[$field] = $value;
+            } else {
+                $this->_data[$field] = $value;
+            }
+        } elseif (in_array($field, self::$relationFields[get_class($this)])) {
             // Set relation
             $this->relation($field, $value);
-        } elseif ($modified) {
-            $this->_dataModified[$field] = $value;
-        } else {
-            $this->_data[$field] = $value;
         }
     }
 


### PR DESCRIPTION
see #131.

The problem was that get and set where not getting/setting the value from the same location (dataModified, data and relation). 

Set was looking in relations first while get was looking in relations last. I encountered the bug because I had a relation that had the same name as a property.