### PR TITLE
Validationmsg

### DIFF
--- a/tests/Validation.php
+++ b/tests/Validation.php
@@ -89,7 +89,7 @@ class Test_Validation extends PHPUnit_Framework_TestCase
         $mapper->save($entity);
 
         $this->assertTrue($entity->hasErrors());
-        $this->assertContains("Email must be longer than 4", $entity->errors('email'));
+        $this->assertContains("must be at least 4 long", $entity->errors('email'));
     }
 
     public function testDisabledValidation()

--- a/tests/Validation.php
+++ b/tests/Validation.php
@@ -89,7 +89,7 @@ class Test_Validation extends PHPUnit_Framework_TestCase
         $mapper->save($entity);
 
         $this->assertTrue($entity->hasErrors());
-        $this->assertContains("must be at least 4 long", $entity->errors('email'));
+        $this->assertContains("Email must be at least 4 long", $entity->errors('email'));
     }
 
     public function testDisabledValidation()


### PR DESCRIPTION
Testing the validation failed because the test was comparing to the wrong message for an invalid e-mail address apparently (the shortest possible e-mail address seems to be 4 characters long, so the message returned by valitron seemed more correct then the one that was in the test)