### PR TITLE
Added alias support to foreign key migration #77

### DIFF
--- a/lib/Query/Resolver.php
+++ b/lib/Query/Resolver.php
@@ -309,8 +309,15 @@ class Resolver
                     $onDelete = "SET NULL";
                 }
 
+                $fieldAliasMappings = $this->mapper->entityManager()->fieldAliasMappings();
+                if ($fieldAliasMappings[$relation->localKey()] !== null) {
+                    $localKey = $fieldAliasMappings[$relation->localKey()];
+                } else {
+                    $localKey = $relation->localKey();
+                }
+
                 $fkName = $this->mapper->table().'_fk_'.$relationName;
-                $table->addForeignKeyConstraint($foreignTable, [$relation->localKey()], [$relation->foreignKey()], ["onDelete" => $onDelete, "onUpdate" => $onUpdate], $fkName);
+                $table->addForeignKeyConstraint($foreignTable, [$localKey], [$relation->foreignKey()], ["onDelete" => $onDelete, "onUpdate" => $onUpdate], $fkName);
             }
         }
 


### PR DESCRIPTION
Pull request to add alias support to foreign keys (#77).

**Bug:** If your foreign key is mapped to an aliased column then the migration fails.

**Example Entity:**
```php
class Example extends \Spot\Entity
{
  protected static $table = 'example';
  public static function fields()
  {
    return [
      'id' => ['type' => 'integer', 'primary' => true, 'autoincrement' => true],
      'officeId' => ['type' => 'integer', 'required' => true, 'column' => 'office_id']
    ];
  }
  public static function relations(Mapper $mapper, Entity $entity)
  {
    return [
      'office' => $mapper->belongsTo($entity, 'Rendelo\Entity\Office', 'officeId')
    ];
  }
}
```