### PR TITLE
Patch for foreign keys (empty variable bug, alias support) #77 #136

### DIFF
--- a/lib/Query/Resolver.php
+++ b/lib/Query/Resolver.php
@@ -331,8 +331,16 @@ class Resolver
                     $onDelete = "SET NULL";
                 }
 
+                // Field alias support
+                $fieldAliasMappings = $this->mapper->entityManager()->fieldAliasMappings();
+                if (isset($fieldAliasMappings[$relation->localKey()])) {
+                    $localKey = $fieldAliasMappings[$relation->localKey()];
+                } else {
+                    $localKey = $relation->localKey();
+                }
+
                 $fkName = $this->mapper->table().'_fk_'.$relationName;
-                $table->addForeignKeyConstraint($foreignTable, [$relation->localKey()], [$relation->foreignKey()], ["onDelete" => $onDelete, "onUpdate" => $onUpdate], $fkName);
+                $table->addForeignKeyConstraint($foreignTable, [$localKey], [$relation->foreignKey()], ["onDelete" => $onDelete, "onUpdate" => $onUpdate], $fkName);
             }
         }
 

--- a/lib/Query/Resolver.php
+++ b/lib/Query/Resolver.php
@@ -286,7 +286,8 @@ class Resolver
      */
     protected function addForeignKeys(Table $table)
     {
-        $relations = $this->mapper->entityManager()->relations();
+        $entityName = $this->mapper->entity();
+        $relations = $entityName::relations($this->mapper, new $entityName);
         $fields = $this->mapper->entityManager()->fields();
         foreach ($relations as $relationName => $relation) {
             if ($relation instanceof BelongsTo) {

--- a/lib/Query/Resolver.php
+++ b/lib/Query/Resolver.php
@@ -267,7 +267,7 @@ class Resolver
 
         return $this->mapper->connection()->quoteIdentifier(trim($identifier));
     }
-	
+
     /**
      * Trim a leading schema name separated by a dot if present
      *
@@ -298,7 +298,9 @@ class Resolver
                     continue;
                 }
 
-                $foreignTable = $relation->mapper()->getMapper($relation->entityName())->table();
+                $foreignTableMapper = $relation->mapper()->getMapper($relation->entityName());
+                $foreignTableMapper->migrate();
+                $foreignTable = $foreignTableMapper->table();
 
                 $onUpdate = !is_null($fieldInfo['onUpdate']) ? $fieldInfo['onUpdate'] :"CASCADE";
 

--- a/tests/CRUD.php
+++ b/tests/CRUD.php
@@ -316,7 +316,7 @@ class CRUD extends \PHPUnit_Framework_TestCase
         $result = $postMapper->save($post, ['strict' => false]);
         $this->assertTrue((boolean) $result);
     }
-    
+
     public function testHasOneRelationValidation()
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Event');
@@ -339,7 +339,7 @@ class CRUD extends \PHPUnit_Framework_TestCase
         $search2 = new Entity\Event\Search(['body' => 'body2']);
         $event->relation('search', $search2);
         $mapper->save($event, ['relations' => true]);
-        
+
         $queryHasOne = $searchMapper->where(['event_id' => $event->id]);
         $this->assertEquals(count($queryHasOne), 1);
         $this->assertEquals($queryHasOne->first()->get('body'), 'body2');
@@ -348,22 +348,22 @@ class CRUD extends \PHPUnit_Framework_TestCase
     public function testBelongsToRelationValidation()
     {
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
-        $author = new \SpotTest\Entity\Author(['email' => 'test@example.com', 'password' => '123456']);
+        $author = new \SpotTest\Entity\Author(['id' => 2, 'email' => 'test@example.com', 'password' => '123456']);
         $post = $mapper->build([
             'title' => 'Test',
             'body' => 'Test description',
         ]);
         $post->relation('author', $author);
         $mapper->save($post, ['relations' => true]);
-        
+
         $this->assertEquals($post->author_id, $author->id);
         $this->assertFalse($post->isNew());
         $this->assertFalse($author->isNew());
 
-        $author2 = new \SpotTest\Entity\Author(['email' => 'test2@example.com', 'password' => '123456789']);
+        $author2 = new \SpotTest\Entity\Author(['id' => 3, 'email' => 'test2@example.com', 'password' => '123456789']);
         $post->relation('author', $author2);
         $mapper->save($post, ['relations' => true]);
-        
+
         $this->assertEquals($post->author_id, $author2->id);
     }
 
@@ -382,7 +382,7 @@ class CRUD extends \PHPUnit_Framework_TestCase
         $post = $mapper->build([
             'title' => 'Test',
             'body' => 'Test description',
-            'author_id' => 5
+            'author_id' => 1
         ]);
         $post->relation('comments', new \Spot\Entity\Collection($comments));
         $mapper->save($post, ['relations' => true]);
@@ -418,7 +418,7 @@ class CRUD extends \PHPUnit_Framework_TestCase
         $post = $mapper->build([
             'title' => 'Test',
             'body' => 'Test description',
-            'author_id' => 5
+            'author_id' => 1
         ]);
         $post->relation('tags', new \Spot\Entity\Collection($tags));
         $mapper->save($post, ['relations' => true]);

--- a/tests/Entity.php
+++ b/tests/Entity.php
@@ -13,6 +13,19 @@ class Entity extends \PHPUnit_Framework_TestCase
         foreach (self::$entities as $entity) {
             test_spot_mapper('\SpotTest\Entity\\' . $entity)->migrate();
         }
+
+        $authorMapper = test_spot_mapper('SpotTest\Entity\Author');
+        $author = $authorMapper->build([
+            'id' => 1,
+            'email' => 'example@example.com',
+            'password' => 't00r',
+            'is_admin' => false
+        ]);
+        $result = $authorMapper->insert($author);
+
+        if (!$result) {
+            throw new \Exception("Unable to create author: " . var_export($author->data(), true));
+        }
     }
 
     public static function tearDownAfterClass()

--- a/tests/Entity/PolymorphicComment.php
+++ b/tests/Entity/PolymorphicComment.php
@@ -18,7 +18,7 @@ class PolymorphicComment extends \Spot\Entity
     {
         return [
             'id'            => ['type' => 'integer', 'primary' => true, 'autoincrement' => true],
-            'item_type'     => ['type' => 'string', 'index' => 'item_type_id', 'required' => true],
+            'item_type'     => ['type' => 'string', 'index' => 'item_type_id', 'required' => true, 'value' => 'post'],
             'item_id'       => ['type' => 'integer', 'index' => 'item_type_id', 'required' => true],
             'name'          => ['type' => 'string', 'required' => true],
             'email'         => ['type' => 'string', 'required' => true],

--- a/tests/Entity/RecursiveEntity.php
+++ b/tests/Entity/RecursiveEntity.php
@@ -42,8 +42,8 @@ class RecursiveEntity extends Entity
             'parent_id' => [
                 'type' => 'integer', 'index' => true,
             ],
-            'sibling_id' => [
-                'type' => 'integer', 'index' => true,
+            'siblingId' => [
+                'type' => 'integer', 'index' => true, 'column' => 'sibling_id'
             ],
         ];
     }
@@ -53,8 +53,8 @@ class RecursiveEntity extends Entity
         return [
             'children' => $mapper->hasMany($entity, 'SpotTest\Entity\RecursiveEntity', 'parent_id'),
             'parent' => $mapper->belongsTo($entity, 'SpotTest\Entity\RecursiveEntity', 'parent_id'),
-            'my_sibling' => $mapper->belongsTo($entity, 'SpotTest\Entity\RecursiveEntity', 'sibling_id'),
-            'sibling' => $mapper->hasOne($entity, 'SpotTest\Entity\RecursiveEntity', 'sibling_id')
+            'my_sibling' => $mapper->belongsTo($entity, 'SpotTest\Entity\RecursiveEntity', 'siblingId'),
+            'sibling' => $mapper->hasOne($entity, 'SpotTest\Entity\RecursiveEntity', 'siblingId')
         ];
     }
 }

--- a/tests/Entity/RecursiveEntity.php
+++ b/tests/Entity/RecursiveEntity.php
@@ -1,0 +1,60 @@
+<?php
+namespace SpotTest\Entity;
+
+use Spot\Entity;
+use Spot\MapperInterface;
+use Spot\EntityInterface;
+
+/**
+ * RecursiveEntity
+ *
+ * @package Spot
+ */
+class RecursiveEntity extends Entity
+{
+    protected static $table = 'test_recursive';
+
+    public static function fields()
+    {
+        return [
+            'id' => [
+                'type' => 'integer', 'primary' => true, 'autoincrement' => true,
+                'form' => false
+            ],
+            'priority' => [
+                'type' => 'integer', 'index' => true,
+                'form' => false,
+            ],
+            'status' => [
+                'type' => 'smallint', 'required' => true, 'default' => 1,
+                'options' => [1, 0],
+            ],
+            'date_publish' => [
+                'type' => 'date',
+            ],
+            'name' => [
+                'type' => 'string', 'required' => true, 'label' => true,
+                'validation' => ['lengthMax' => 255],
+            ],
+            'description' => [
+                'type' => 'text'
+            ],
+            'parent_id' => [
+                'type' => 'integer', 'index' => true,
+            ],
+            'sibling_id' => [
+                'type' => 'integer', 'index' => true,
+            ],
+        ];
+    }
+
+    public static function relations(MapperInterface $mapper, EntityInterface $entity)
+    {
+        return [
+            'children' => $mapper->hasMany($entity, 'SpotTest\Entity\RecursiveEntity', 'parent_id'),
+            'parent' => $mapper->belongsTo($entity, 'SpotTest\Entity\RecursiveEntity', 'parent_id'),
+            'my_sibling' => $mapper->belongsTo($entity, 'SpotTest\Entity\RecursiveEntity', 'sibling_id'),
+            'sibling' => $mapper->hasOne($entity, 'SpotTest\Entity\RecursiveEntity', 'sibling_id')
+        ];
+    }
+}

--- a/tests/Events.php
+++ b/tests/Events.php
@@ -6,7 +6,7 @@ namespace SpotTest;
  */
 class Events extends \PHPUnit_Framework_TestCase
 {
-    private static $entities = ['Post', 'Post\Comment', 'Tag', 'PostTag', 'Author'];
+    private static $entities = ['PostTag', 'Post\Comment', 'Post', 'Tag', 'Author'];
 
     public static function setupBeforeClass()
     {
@@ -20,7 +20,7 @@ class Events extends \PHPUnit_Framework_TestCase
                 'name' => "Title {$i}"
             ]);
         }
-        for ($i = 1; $i <= 3; $i++) {
+        for ($i = 1; $i <= 4; $i++) {
             $author_id = test_spot_mapper('SpotTest\Entity\Author')->insert([
                 'email' => $i.'user@somewhere.com',
                 'password' => 'securepassword'
@@ -156,7 +156,7 @@ class Events extends \PHPUnit_Framework_TestCase
             'title' => 'A title',
             'body' => '<p>body</p>',
             'status' => 1,
-            'author_id' => 1234,
+            'author_id' => 4,
             'date_created' => new \DateTime()
         ]);
 
@@ -165,7 +165,7 @@ class Events extends \PHPUnit_Framework_TestCase
             $post->status = 2;
         });
         $mapper->save($post);
-        $post = $mapper->first(['author_id' => 1234]);
+        $post = $mapper->first(['author_id' => 4]);
         $this->assertEquals(2, $post->status);
 
         $eventEmitter->removeAllListeners('beforeInsert');
@@ -216,6 +216,12 @@ class Events extends \PHPUnit_Framework_TestCase
     public function testUpdateHookUpdatesProperly()
     {
         $author_id = __LINE__;
+        $author = test_spot_mapper('SpotTest\Entity\Author')->insert([
+            'id' => $author_id,
+            'email' => $author_id.'user@somewhere.com',
+            'password' => 'securepassword'
+        ]);
+
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
         $testcase = $this;
 

--- a/tests/FieldAlias.php
+++ b/tests/FieldAlias.php
@@ -8,18 +8,46 @@ use SpotTest\Entity\Legacy;
 class FieldAlias extends \PHPUnit_Framework_TestCase
 {
     public static $legacyTable;
+    private static $entities = ['PolymorphicComment', 'Legacy', 'Post', 'Author'];
 
     public static function setupBeforeClass()
     {
         self::$legacyTable = new \SpotTest\Entity\Legacy();
-        foreach (['Legacy', 'PolymorphicComment'] as $entity) {
+        foreach (self::$entities as $entity) {
             test_spot_mapper('SpotTest\Entity\\' . $entity)->migrate();
+        }
+
+        $authorMapper = test_spot_mapper('SpotTest\Entity\Author');
+        $author = $authorMapper->build([
+            'id' => 1,
+            'email' => 'example@example.com',
+            'password' => 't00r',
+            'is_admin' => false
+        ]);
+        $result = $authorMapper->insert($author);
+
+        if (!$result) {
+            throw new \Exception("Unable to create author: " . var_export($author->data(), true));
+        }
+
+        $postMapper = test_spot_mapper('SpotTest\Entity\Post');
+        $post = $postMapper->build([
+            'title' => 'title',
+            'body' => '<p>body</p>',
+            'status' => 1 ,
+            'date_created' => new \DateTime(),
+            'author_id' => 1
+        ]);
+        $result = $postMapper->insert($post);
+
+        if (!$result) {
+            throw new \Exception("Unable to create post: " . var_export($post->data(), true));
         }
     }
 
     public static function tearDownAfterClass()
     {
-        foreach (['Legacy', 'PolymorphicComment'] as $entity) {
+        foreach (self::$entities as $entity) {
             test_spot_mapper('\SpotTest\Entity\\' . $entity)->dropTable();
         }
     }

--- a/tests/ForeignKeys.php
+++ b/tests/ForeignKeys.php
@@ -1,0 +1,22 @@
+<?php
+namespace SpotTest;
+
+/**
+ * @package Spot
+ */
+class ForeignKeys extends \PHPUnit_Framework_TestCase
+{
+
+    public function testForeignKeyMigration()
+    {
+        $mapper = test_spot_mapper('\SpotTest\Entity\Post');
+        $mapper->migrate();
+
+        $entity = $mapper->entity();
+        $table = $entity::table();
+        $schemaManager = $mapper->connection()->getSchemaManager();
+        $foreignKeys = $schemaManager->listTableForeignKeys($table);
+
+        $this->assertEquals(1, count($foreignKeys));
+    }
+}

--- a/tests/ForeignKeys.php
+++ b/tests/ForeignKeys.php
@@ -6,12 +6,25 @@ namespace SpotTest;
  */
 class ForeignKeys extends \PHPUnit_Framework_TestCase
 {
+    private static $entities = ['Post', 'Author'];
+
+    public static function setupBeforeClass()
+    {
+        foreach (self::$entities as $entity) {
+            test_spot_mapper('\SpotTest\Entity\\' . $entity)->migrate();
+        }
+    }
+
+    public static function tearDownAfterClass()
+    {
+        foreach (self::$entities as $entity) {
+            test_spot_mapper('\SpotTest\Entity\\' . $entity)->dropTable();
+        }
+    }
 
     public function testForeignKeyMigration()
     {
         $mapper = test_spot_mapper('\SpotTest\Entity\Post');
-        $mapper->migrate();
-
         $entity = $mapper->entity();
         $table = $entity::table();
         $schemaManager = $mapper->connection()->getSchemaManager();

--- a/tests/ForeignKeys.php
+++ b/tests/ForeignKeys.php
@@ -6,7 +6,7 @@ namespace SpotTest;
  */
 class ForeignKeys extends \PHPUnit_Framework_TestCase
 {
-    private static $entities = ['Post', 'Author'];
+    private static $entities = ['Post', 'Author', 'RecursiveEntity'];
 
     public static function setupBeforeClass()
     {

--- a/tests/Insert.php
+++ b/tests/Insert.php
@@ -6,12 +6,25 @@ namespace SpotTest;
  */
 class Insert extends \PHPUnit_Framework_TestCase
 {
-    private static $entities = ['Post', 'Author', 'Event', 'Event\Search', 'NoSerial'];
+    private static $entities = ['Post', 'Author', 'Event\Search', 'Event', 'NoSerial'];
 
     public static function setupBeforeClass()
     {
         foreach (self::$entities as $entity) {
             test_spot_mapper('\SpotTest\Entity\\' . $entity)->migrate();
+        }
+
+        $authorMapper = test_spot_mapper('SpotTest\Entity\Author');
+        $author = $authorMapper->build([
+            'id' => 1,
+            'email' => 'example@example.com',
+            'password' => 't00r',
+            'is_admin' => false
+        ]);
+        $result = $authorMapper->insert($author);
+
+        if (!$result) {
+            throw new \Exception("Unable to create author: " . var_export($author->data(), true));
         }
     }
 
@@ -79,7 +92,7 @@ class Insert extends \PHPUnit_Framework_TestCase
         $mapper = test_spot_mapper('\SpotTest\Entity\Post');
         $post = [
             'title' => "Test Post 101",
-            'author_id' => 101,
+            'author_id' => 1,
             'body' => "<p>Test Post 101</p><p>It's really quite lovely.</p>",
             'date_created' => new \DateTime()
         ];
@@ -93,7 +106,7 @@ class Insert extends \PHPUnit_Framework_TestCase
         $mapper = test_spot_mapper('\SpotTest\Entity\Post');
         $post = [
             'title' => "Test Post 100",
-            'author_id' => 100,
+            'author_id' => 1,
             'body' => "<p>Test Post 100</p>",
             'date_created' => new \DateTime()
         ];
@@ -109,7 +122,7 @@ class Insert extends \PHPUnit_Framework_TestCase
         $mapper = test_spot_mapper('\SpotTest\Entity\Post');
         $post = [
             'title' => "Test Post 101",
-            'author_id' => 101,
+            'author_id' => 1,
             'body' => "<p>Test Post 101</p>",
             'date_created' => new \DateTime()
         ];
@@ -125,7 +138,7 @@ class Insert extends \PHPUnit_Framework_TestCase
         $post = new \SpotTest\Entity\Post([
             'id' => 2001,
             'title' => "Test Post 2001",
-            'author_id' => 2001,
+            'author_id' => 1,
             'body' => "<p>Test Post 2001</p>"
         ]);
         $result = $mapper->insert($post);

--- a/tests/Relations.php
+++ b/tests/Relations.php
@@ -301,6 +301,7 @@ class Relations extends \PHPUnit_Framework_TestCase
         $authorMapper = test_spot_mapper('SpotTest\Entity\Author');
 
         $author = $authorMapper->create([
+            'id' => 2,
             'email'    => $email,
             'password' => 'password',
             'is_admin' => false,
@@ -320,6 +321,7 @@ class Relations extends \PHPUnit_Framework_TestCase
         $authorMapper = test_spot_mapper('SpotTest\Entity\Author');
 
         $author = $authorMapper->create([
+            'id' => 3,
             'email'    => 'test1@test.com',
             'password' => 'password',
             'is_admin' => false,

--- a/tests/Relations.php
+++ b/tests/Relations.php
@@ -6,12 +6,25 @@ namespace SpotTest;
  */
 class Relations extends \PHPUnit_Framework_TestCase
 {
-    private static $entities = ['Post', 'Post\Comment', 'Author', 'Tag', 'PostTag', 'Event', 'Event\Search'];
+    private static $entities = ['PostTag', 'Post\Comment', 'Post', 'Tag', 'Author', 'Event\Search', 'Event'];
 
     public static function setupBeforeClass()
     {
         foreach (self::$entities as $entity) {
             test_spot_mapper('\SpotTest\Entity\\' . $entity)->migrate();
+        }
+
+        $authorMapper = test_spot_mapper('SpotTest\Entity\Author');
+        $author = $authorMapper->build([
+            'id' => 1,
+            'email' => 'example@example.com',
+            'password' => 't00r',
+            'is_admin' => false
+        ]);
+        $result = $authorMapper->insert($author);
+
+        if (!$result) {
+            throw new \Exception("Unable to create author: " . var_export($author->data(), true));
         }
     }
 

--- a/tests/RelationsEagerLoading.php
+++ b/tests/RelationsEagerLoading.php
@@ -6,7 +6,7 @@ namespace SpotTest;
  */
 class RelationsEagerLoading extends \PHPUnit_Framework_TestCase
 {
-    private static $entities = ['Post', 'Post\Comment', 'Author', 'Tag', 'PostTag', 'Event', 'Event\Search'];
+    private static $entities = ['PostTag', 'Post\Comment', 'Post', 'Tag', 'Author', 'Event\Search', 'Event'];
 
     public static function setupBeforeClass()
     {

--- a/tests/RelationsPolymorphic.php
+++ b/tests/RelationsPolymorphic.php
@@ -6,7 +6,7 @@ namespace SpotTest;
  */
 class RelationsPolymorphic extends \PHPUnit_Framework_TestCase
 {
-    private static $entities = ['Author', 'Post', 'Event', 'Event\Search', 'PolymorphicComment'];
+    private static $entities = ['PolymorphicComment', 'Post', 'Author', 'Event\Search', 'Event'];
 
     public static function setupBeforeClass()
     {

--- a/tests/Scopes.php
+++ b/tests/Scopes.php
@@ -6,16 +6,31 @@ namespace SpotTest;
  */
 class Scopes extends \PHPUnit_Framework_TestCase
 {
+    private static $entities = ['Post\Comment', 'Post', 'Event\Search', 'Event', 'Author'];
+
     public static function setupBeforeClass()
     {
-        foreach (['Post', 'Post\Comment', 'Event', 'Event\Search', 'Author'] as $entity) {
+        foreach (self::$entities as $entity) {
             test_spot_mapper('\SpotTest\Entity\\' . $entity)->migrate();
+        }
+
+        $authorMapper = test_spot_mapper('SpotTest\Entity\Author');
+        $author = $authorMapper->build([
+            'id' => 1,
+            'email' => 'example@example.com',
+            'password' => 't00r',
+            'is_admin' => false
+        ]);
+        $result = $authorMapper->insert($author);
+
+        if (!$result) {
+            throw new \Exception("Unable to create author: " . var_export($author->data(), true));
         }
     }
 
     public static function tearDownAfterClass()
     {
-        foreach (['Post', 'Post\Comment', 'Event', 'Event\Search', 'Author'] as $entity) {
+        foreach (self::$entities as $entity) {
             test_spot_mapper('\SpotTest\Entity\\' . $entity)->dropTable();
         }
     }

--- a/tests/Transactions.php
+++ b/tests/Transactions.php
@@ -6,12 +6,25 @@ namespace SpotTest;
  */
 class Transactions extends \PHPUnit_Framework_TestCase
 {
-    private static $entities = ['Post'];
+    private static $entities = ['Post', 'Author'];
 
     public static function setupBeforeClass()
     {
         foreach (self::$entities as $entity) {
             test_spot_mapper('\SpotTest\Entity\\' . $entity)->migrate();
+        }
+
+        $authorMapper = test_spot_mapper('SpotTest\Entity\Author');
+        $author = $authorMapper->build([
+            'id' => 1,
+            'email' => 'example@example.com',
+            'password' => 't00r',
+            'is_admin' => false
+        ]);
+        $result = $authorMapper->insert($author);
+
+        if (!$result) {
+            throw new \Exception("Unable to create author: " . var_export($author->data(), true));
         }
     }
 


### PR DESCRIPTION
Pull request to patch the addForeignKeys() function added in PR #136 

**Issue 1:** The $relations variable is empty and the migration fails (@Schrank could reproduce the problem).
**Issue 2:** If your foreign key is mapped to an aliased column then the migration fails.

**Example Entity:**
```php
class Example extends \Spot\Entity
{
  protected static $table = 'example';
  public static function fields()
  {
    return [
      'id' => ['type' => 'integer', 'primary' => true, 'autoincrement' => true],
      'officeId' => ['type' => 'integer', 'required' => true, 'column' => 'office_id']
    ];
  }
  public static function relations(Mapper $mapper, Entity $entity)
  {
    return [
      'office' => $mapper->belongsTo($entity, 'Rendelo\Entity\Office', 'officeId')
    ];
  }
}
```
