### PR TITLE
make Query::parseWhereToSQLFragments protected

### DIFF
--- a/lib/Query.php
+++ b/lib/Query.php
@@ -311,7 +311,7 @@ class Query implements \Countable, \IteratorAggregate, \ArrayAccess, \JsonSerial
      * @return array SQL fragment strings for WHERE clause
      * @throws Exception
      */
-    private function parseWhereToSQLFragments(array $where, $useAlias = true)
+    protected function parseWhereToSQLFragments(array $where, $useAlias = true)
     {
         $builder = $this->builder();
 


### PR DESCRIPTION
Making Query::parseWhereToSQLFragments protected allows someone to override it and add custom operators (such as JSONB operators)