### PR TITLE
Fix for error when calling mapper loadRelations method manually for entities loaded from a cache instead of DB

### DIFF
--- a/lib/Entity.php
+++ b/lib/Entity.php
@@ -537,7 +537,10 @@ abstract class Entity implements EntityInterface, \JsonSerializable
 
             // Add to relation field array
             $entityName = get_class($this);
-            if (!in_array($relationName, self::$relationFields[$entityName])) {
+            if (!isset(self::$relationFields[$entityName]) || !in_array($relationName, self::$relationFields[$entityName])) {
+                if (!isset(self::$relationFields[$entityName])) {
+                    self::$relationFields[$entityName] = [];
+                }
                 self::$relationFields[$entityName][] = $relationName;
             }
         }


### PR DESCRIPTION
In some cases such as entities are retrieved from a cache the relationships are not found. This will cause problems while updating the entity. In order to resolve this issue we can call loadRelations method of the mapper. But this triggers an error if self::$relationFields[$entityName] is not set