### PR TITLE
FEATURE: Update doctrine/dbal depedency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.4.0",
         "vlucas/valitron": "~1.1",
-        "doctrine/dbal": "2.5.4",
+        "doctrine/dbal": "^2.5.4",
         "sabre/event": "~2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hi,

I've changed the dependency requirements against `doctrine/dbal` so that it can use `v2.5.5`

I've run the test on php7 so far : 

```
$ php vendor/phpunit/phpunit/phpunit -c phpunit_mysql.xml                                                                                                                                                                                  PHPUnit 4.8.27 by Sebastian Bergmann and contributors.

...............................................................  63 / 198 ( 31%)
............................................................... 126 / 198 ( 63%)
............................................................... 189 / 198 ( 95%)
.........

Time: 1.75 seconds, Memory: 12.00MB

OK (198 tests, 418 assertions)
```
