### PR TITLE
FEATURE: Allows field to be indexed in multiple compound indexes

### DIFF
--- a/lib/Entity/Manager.php
+++ b/lib/Entity/Manager.php
@@ -259,24 +259,41 @@ class Manager
                 $tableKeys['primary'][] = $fieldName;
             }
             if ($fieldInfo['unique']) {
-                if (is_string($fieldInfo['unique'])) {
-                    // Named group
-                    $fieldKeyName = $table . '_' . $fieldInfo['unique'];
-                }
+                $fieldKeyName = $this->computeIndexName($table, $fieldInfo['unique'])?:$fieldKeyName;
                 $tableKeys['unique'][$fieldKeyName][] = $fieldName;
                 $usedKeyNames[] = $fieldKeyName;
             }
             if ($fieldInfo['index']) {
-                if (is_string($fieldInfo['index'])) {
-                    // Named group
-                    $fieldKeyName = $table . '_' . $fieldInfo['index'];
+                if (!is_array($fieldInfo['index'])) {
+                    $fieldInfo['index'] = [$fieldInfo['index']];
                 }
-                $tableKeys['index'][$fieldKeyName][] = $fieldName;
-                $usedKeyNames[] = $fieldKeyName;
+                foreach ($fieldInfo['index'] as $fieldInfoIndex) {
+                    $fieldKeyName = $this->computeIndexName($table, $fieldInfoIndex)?:$fieldKeyName;
+                    $tableKeys['index'][$fieldKeyName][] = $fieldName;
+                    $usedKeyNames[] = $fieldKeyName;
+                }
             }
         }
 
         return $tableKeys;
+    }
+
+    /**
+     * Attempt to generate a user-suffixed index name
+     *
+     * @param  string       $table
+     * @param  string|bool  $indexConfiguration
+     *
+     * @return string|bool
+     */
+    private function computeIndexName($table, $indexConfiguration)
+    {
+        if (is_string($indexConfiguration)) {
+            // Index name based on user-defined configuration
+            return $table . '_' . $indexConfiguration;
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Entity/MultipleIndexedField.php
+++ b/tests/Entity/MultipleIndexedField.php
@@ -1,0 +1,24 @@
+<?php
+namespace SpotTest\Entity;
+
+use Spot\Entity;
+
+/**
+ * Entity with fields in compound index and in non-compound index
+ *
+ * @package Spot
+ */
+class MultipleIndexedField extends \Spot\Entity
+{
+    protected static $table = 'test_multipleindexedfield';
+
+    public static function fields()
+    {
+        return [
+            'id'            => ['type' => 'integer', 'primary' => true],
+            'companyGroup'  => ['type' => 'integer', 'required' => false, 'index' => true],
+            'company'       => ['type' => 'integer', 'required' => false, 'index' => [true, 'employee']],
+            'user'          => ['type' => 'string', 'required' => false, 'index' => [true, 'employee']],
+        ];
+    }
+}

--- a/tests/Manager.php
+++ b/tests/Manager.php
@@ -16,4 +16,21 @@ class Manager extends \PHPUnit_Framework_TestCase
         $this->assertTrue($fields['data2']['notnull']); // Should override to true
         $this->assertFalse($fields['data3']['notnull']); // Should override to false
     }
+
+    public function testMultipleIndexedField()
+    {
+        $mapper = test_spot_mapper('SpotTest\Entity\MultipleIndexedField');
+        $manager = $mapper->entityManager();
+        $fieldKeys = $manager->fieldKeys();
+
+        // companyGroup, company and user must be indexed separately
+        $this->assertTrue(array_key_exists('test_multipleindexedfield_companyGroup', $fieldKeys['index']));
+        $this->assertTrue(array_key_exists('test_multipleindexedfield_company', $fieldKeys['index']));
+        $this->assertTrue(array_key_exists('test_multipleindexedfield_user', $fieldKeys['index']));
+
+        // an "employee" index must exist with company and user field
+        $this->assertTrue(array_key_exists('test_multipleindexedfield_employee', $fieldKeys['index']));
+        $this->assertContains('company', $fieldKeys['index']['test_multipleindexedfield_employee']);
+        $this->assertContains('user', $fieldKeys['index']['test_multipleindexedfield_employee']);
+    }
 }


### PR DESCRIPTION
This PR slightly modifies the 'index' argument of a field definition.
It allows to define compound index on fields that are already in other index scope.
## usage :

``` PHP
<?php
namespace SpotTest\Entity;

use Spot\Entity;

/**
 * Entity with fields in compound index and in non-compound index
 *
 * @package Spot
 */
class MultipleIndexedField extends \Spot\Entity
{
    protected static $table = 'test_multipleindexedfield';

    public static function fields()
    {
        return [
            'id'            => ['type' => 'integer', 'primary' => true],
            'companyGroup'  => ['type' => 'integer', 'required' => false, 'index' => true],
            'company'       => ['type' => 'integer', 'required' => false, 'index' => [true, 'employee']],
            'user'          => ['type' => 'string', 'required' => false, 'index' => [true, 'employee']],
        ];
    }
}

```
## tests (mysql):

```
$ phpunit -c phpunit_mysql.xml                                                                                                            
PHPUnit 4.8.27 by Sebastian Bergmann and contributors.

...............................................................  63 / 199 ( 31%)
............................................................... 126 / 199 ( 63%)
............................................................... 189 / 199 ( 94%)
..........                                                      199 / 199 (100%)

Time: 2.9 seconds, Memory: 10.00MB

OK (199 tests, 424 assertions)
```
