### PR TITLE
Fix Mapper::query() method to pass param types.

### DIFF
--- a/lib/Mapper.php
+++ b/lib/Mapper.php
@@ -559,10 +559,11 @@ class Mapper implements MapperInterface
      *
      * @param string         $sql        Raw query or SQL to run against the datastore
      * @param array Optional $conditions Array of binds in column => value pairs to use for prepared statement
+     * @param array Optional $types      Array of DBAL column types (e.g. to specify custom type for IN () condition)
      */
-    public function query($sql, array $params = [])
+    public function query($sql, array $params = [], array $types = [])
     {
-        $result = $this->connection()->executeQuery($sql, $params);
+        $result = $this->connection()->executeQuery($sql, $params, $types);
         if ($result) {
             return $this->collection($result);
         }


### PR DESCRIPTION
When using custom query, it's not possible to use custom types for query parameters. For example:
```
$mapper->query(
    'SELECT * FROM user WHERE state IN (?)',
    [
        ['pending', 'active']
    ],
    [
        \Doctrine\DBAL\Connection::PARAM_STR_ARRAY
    ]
);
```

This pull request fixes the problem by passing custom param types to \Doctrine\DBAL\Connection::executeQuery() via Mapper::query().