### PR TITLE
Travis build fixes (PHP 7.1, HHVM)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,6 @@ php:
   - 7.1
   - hhvm
 
-matrix:
-    allow_failures:
-        - php: hhvm
-        - php: 7.1
-
 env:
   - TYPE=mysql DSN=mysql://root@localhost/spot_test
   - TYPE=pgsql DSN=pgsql://postgres@localhost/spot_test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ install:
 before_script:
   - if [[ "$TYPE" == "mysql" ]]; then mysql -e "create database IF NOT EXISTS spot_test;" -uroot; fi
   - if [[ "$TYPE" == "pgsql" ]]; then psql -c 'create database spot_test;' -U postgres; fi
-
+  - if [[ "$TYPE" == "sqlite" && "$TRAVIS_PHP_VERSION" == "hhvm" ]]; then echo 'open_basedir = none' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
+  
 # omitting "script:" will default to phpunit
 # use the $TYPE env variable to determine the phpunit.xml to use
 script: vendor/bin/phpunit --configuration phpunit_$TYPE.xml --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,14 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - nightly
   - hhvm
+  
+matrix:
+  allow_failures:
+    - php: nightly
+    - php: hhvm
 
 env:
   - TYPE=mysql DSN=mysql://root@localhost/spot_test
@@ -27,7 +34,6 @@ install:
 before_script:
   - if [[ "$TYPE" == "mysql" ]]; then mysql -e "create database IF NOT EXISTS spot_test;" -uroot; fi
   - if [[ "$TYPE" == "pgsql" ]]; then psql -c 'create database spot_test;' -U postgres; fi
-  - if [[ "$TYPE" == "sqlite" && "$TRAVIS_PHP_VERSION" == "hhvm" ]]; then echo 'open_basedir = none' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
   
 # omitting "script:" will default to phpunit
 # use the $TYPE env variable to determine the phpunit.xml to use

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,33 +8,44 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
+  - 7.1
+  - 7.0
+  - 5.6
+  - 5.5
+  - 5.4
   - nightly
   - hhvm
   
 matrix:
   allow_failures:
     - php: nightly
-    - php: hhvm
+    - php: hhvm # run build against hhvm but allow them to fail
 
 env:
   - TYPE=mysql DSN=mysql://root@localhost/spot_test
   - TYPE=pgsql DSN=pgsql://postgres@localhost/spot_test"
-  - TYPE=sqlite DSN=sqlite::memory
+  - TYPE=sqlite DSN=sqlite:/tmp/db.sqlite
 
 install:
   - composer install
 
 # execute any number of scripts before the test run, custom env's are available as variables
 before_script:
+  # Disable the HHVM JIT for faster Unit Testing
+  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then 
+      echo 'hhvm.jit = 0' >> /etc/hhvm/php.ini;
+      echo 'open_basedir = /tmp' >> /etc/hhvm/php.ini;
+    fi
+  # Disable DEPRECATE messages during PHPUnit initialization on PHP 7.2. To fix them, PHPUnit should be updated to 6.*
+  - if [[ $TRAVIS_PHP_VERSION == 7.2 ]] || [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+      echo 'Disabled DEPRECATED notifications for PHP 7.2';
+      echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> /tmp/php-config.ini;
+      phpenv config-add /tmp/php-config.ini;
+    fi
   - if [[ "$TYPE" == "mysql" ]]; then mysql -e "create database IF NOT EXISTS spot_test;" -uroot; fi
   - if [[ "$TYPE" == "pgsql" ]]; then psql -c 'create database spot_test;' -U postgres; fi
-  
+
 # omitting "script:" will default to phpunit
 # use the $TYPE env variable to determine the phpunit.xml to use
 script: vendor/bin/phpunit --configuration phpunit_$TYPE.xml --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
   # Disable the HHVM JIT for faster Unit Testing
   - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then 
       echo 'hhvm.jit = 0' >> /etc/hhvm/php.ini;
-      echo 'open_basedir = /tmp' >> /etc/hhvm/php.ini;
+      echo 'open_basedir = /tmp:/home/travis/' >> /etc/hhvm/php.ini;
     fi
   # Disable DEPRECATE messages during PHPUnit initialization on PHP 7.2. To fix them, PHPUnit should be updated to 6.*
   - if [[ $TRAVIS_PHP_VERSION == 7.2 ]] || [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -189,7 +189,7 @@ class Config implements \Serializable
             $parsed['dbsyntax'] = $str;
         }
 
-        if ( !count( $dsn ) ) {
+        if ( !isset( $dsn ) ) {
             return $parsed;
         }
 

--- a/tests/Entity.php
+++ b/tests/Entity.php
@@ -37,6 +37,7 @@ class Entity extends \PHPUnit_Framework_TestCase
 
     public function testEntitySetDataProperties()
     {
+        $currentDateTime = new \DateTime();
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
         $post = new \SpotTest\Entity\Post();
 
@@ -44,6 +45,7 @@ class Entity extends \PHPUnit_Framework_TestCase
         $post->title = "My Awesome Post";
         $post->body = "<p>Body</p>";
         $post->author_id = 1;
+        $post->date_created = $currentDateTime;
 
         $data = $post->data();
         ksort($data);
@@ -53,7 +55,7 @@ class Entity extends \PHPUnit_Framework_TestCase
             'title' => 'My Awesome Post',
             'body' => '<p>Body</p>',
             'status' => 0,
-            'date_created' => new \DateTime(),
+            'date_created' => $currentDateTime,
             'data' => null,
             'author_id' => 1
         ];
@@ -66,14 +68,15 @@ class Entity extends \PHPUnit_Framework_TestCase
 
     public function testEntitySetDataConstruct()
     {
+        $currentDateTime = new \DateTime();
         $mapper = test_spot_mapper('SpotTest\Entity\Post');
         $post = new \SpotTest\Entity\Post([
             'title' => 'My Awesome Post',
             'body' => '<p>Body</p>',
             'author_id' => 1,
-            'date_created' => new \DateTime()
+            'date_created' => $currentDateTime
         ]);
-
+        
         $data = $post->data();
         ksort($data);
 
@@ -85,7 +88,7 @@ class Entity extends \PHPUnit_Framework_TestCase
             'date_created' => null,
             'data' => null,
             'author_id' => 1,
-            'date_created' => new \DateTime()
+            'date_created' => $currentDateTime
         ];
         ksort($testData);
 

--- a/tests/Relations.php
+++ b/tests/Relations.php
@@ -102,6 +102,7 @@ class Relations extends \PHPUnit_Framework_TestCase
         $post = $mapper->get();
         $post->title = "No Comments";
         $post->body = "<p>Comments relation test</p>";
+        $post->author_id = 1;
         $mapper->save($post);
 
         $this->assertSame(0, count($post->comments));

--- a/tests/Type/Encrypted.php
+++ b/tests/Type/Encrypted.php
@@ -66,3 +66,21 @@ class Encrypted extends Type
         }
     }
 }
+
+/* 
+ * Added hash_equals to support PHP 5.4 and PHP 5.5
+ * hash_equals is built-in from PHP 5.6
+ * Source: http://php.net/manual/en/function.hash-equals.php
+ */
+if(!function_exists('hash_equals')) {
+    function hash_equals($str1, $str2) {
+        if(strlen($str1) != strlen($str2)) {
+            return false;
+        } else {
+            $res = $str1 ^ $str2;
+            $ret = 0;
+            for($i = strlen($res) - 1; $i >= 0; $i--) $ret |= ord($res[$i]);
+            return !$ret;
+        }
+    }
+}

--- a/tests/Type/Encrypted.php
+++ b/tests/Type/Encrypted.php
@@ -7,11 +7,13 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 class Encrypted extends Type
 {
     public static $key;
+    private static $hashing = 'SHA256';
+    private static $cipher = 'AES-128-CBC';
 
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
         if (is_string($value)) {
-            $value = self::aes256_decrypt(self::$key, base64_decode($value));
+            $value = self::aes256_decrypt(self::$key, self::$hashing, self::$cipher, base64_decode($value));
         } else {
             $value = null;
         }
@@ -21,7 +23,7 @@ class Encrypted extends Type
 
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
-        return base64_encode(self::aes256_encrypt(self::$key, $value));
+        return base64_encode(self::aes256_encrypt(self::$key, self::$hashing, self::$cipher, $value));
     }
 
     public function getName()
@@ -34,21 +36,33 @@ class Encrypted extends Type
         return 'TEXT';
     }
 
-    private function aes256_encrypt($key, $data)
+    private function aes256_encrypt($key, $hashing, $cipher, $data)
     {
-      if(32 !== strlen($key)) $key = hash('SHA256', $key, true);
-      $padding = 16 - (strlen($data) % 16);
-      $data .= str_repeat(chr($padding), $padding);
-
-      return mcrypt_encrypt(MCRYPT_RIJNDAEL_128, $key, $data, MCRYPT_MODE_CBC, str_repeat("\0", 16));
+        if(32 !== strlen($key)) $key = hash($hashing, $key, true);
+      
+        $ivlen = openssl_cipher_iv_length($cipher);
+        $iv = openssl_random_pseudo_bytes($ivlen);
+        $ciphertext_raw = openssl_encrypt($data, $cipher, $key, $options = OPENSSL_RAW_DATA, $iv);
+        $hmac = hash_hmac($hashing, $ciphertext_raw, $key, $as_binary = true);
+        
+        return $iv.$hmac.$ciphertext_raw;
     }
 
-    private function aes256_decrypt($key, $data)
+    private function aes256_decrypt($key, $hashing, $cipher, $data)
     {
-      if(32 !== strlen($key)) $key = hash('SHA256', $key, true);
-      $data = mcrypt_decrypt(MCRYPT_RIJNDAEL_128, $key, $data, MCRYPT_MODE_CBC, str_repeat("\0", 16));
-      $padding = ord($data[strlen($data) - 1]);
-
-      return substr($data, 0, -$padding);
+        if(32 !== strlen($key)) $key = hash($hashing, $key, true);
+        
+        $ivlen = openssl_cipher_iv_length($cipher);
+        $iv = substr($data, 0, $ivlen);
+        $hmac = substr($data, $ivlen, $sha2len = 32);
+        $ciphertext_raw = substr($data, $ivlen + $sha2len);
+        $original = openssl_decrypt($ciphertext_raw, $cipher, $key, $options = OPENSSL_RAW_DATA, $iv);
+        $calcmac = hash_hmac($hashing, $ciphertext_raw, $key, $as_binary = true);
+        
+        if (hash_equals($hmac, $calcmac)) { // PHP 5.6+ timing attack safe comparison
+            return $original;
+        } else {
+            throw new \RuntimeException("Timing attack safe string comparison failed.");
+        }
     }
 }


### PR DESCRIPTION
Still work in progress.

Bugs that cause the build to fail:
- [x] PHP7.1 (mysql, pgsql, sqlite): Function mcrypt_encrypt() is deprecated
- [x] PHP7.1 (mysql, pgsql, sqlite): Failed asserting that two arrays are equal (DateTime values)
- [ ] HHVM (sqlite): exception 'PDOException' with message 'safe_mode/open_basedir prohibits opening

Todo:
- [ ] Implement additional DSN parser tests (#36, #264)